### PR TITLE
Fix port number for local running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To run the app locally:
 bundle exec jekyll serve --watch --baseurl ''
 ```
 
-The app will appear at http://127.0.0.1:4567/.
+The app will appear at http://127.0.0.1:4000/
 
 ### Data generation
 


### PR DESCRIPTION
Running `bundle exec jekyll serve --watch --baseurl ''` starts the app
on `4000`, not `4567` for me.

Also drop the period, so the address is easier to copy and paste.