### PR TITLE
Add document types documentation

### DIFF
--- a/_data/content_stats.json
+++ b/_data/content_stats.json
@@ -1,0 +1,3375 @@
+{
+  "document_types": [
+    {
+      "name": "special_route",
+      "count": 38,
+      "schema_names": [
+        "special_route"
+      ],
+      "publishing_apps": [
+        "frontend",
+        "govuk_content_api",
+        "static",
+        "feedback",
+        "whitehall",
+        "design-principles",
+        "contacts",
+        "info-frontend",
+        "share-sale-publisher",
+        "spotlight",
+        "performanceplatform-big-screen-view",
+        "rummager",
+        "tariff"
+      ],
+      "rendering_apps": [
+        "frontend",
+        "publicapi",
+        "static",
+        "feedback",
+        "whitehall-frontend",
+        "designprinciples",
+        "contacts-frontend-old",
+        "info-frontend",
+        "email-campaign-frontend",
+        "spotlight",
+        "performanceplatform-big-screen-view",
+        "rummager",
+        "tariff"
+      ],
+      "examples": [
+        "/",
+        "/api",
+        "/apple-touch-icon-114x114.png",
+        "/apple-touch-icon-144x144.png",
+        "/apple-touch-icon-57x57.png",
+        "/apple-touch-icon-72x72.png",
+        "/apple-touch-icon-precomposed.png",
+        "/apple-touch-icon.png",
+        "/contact",
+        "/courts-tribunals"
+      ]
+    },
+    {
+      "name": "business_support",
+      "count": 639,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/1-1-business-advice",
+        "/2kt-innovation-fund",
+        "/aberdare-townscape-enhancement-programme",
+        "/aberdare-townscape-heritage-initiative",
+        "/aberdeen-city-and-shire-first-employee-grant-scheme",
+        "/access-to-finance-nw",
+        "/access-to-work-london",
+        "/access-to-work-wales",
+        "/acorn-business-centre",
+        "/active-belfast-grants"
+      ]
+    },
+    {
+      "name": "redirect",
+      "count": 14710,
+      "schema_names": [
+        "redirect"
+      ],
+      "publishing_apps": [
+        "whitehall",
+        "short-url-manager",
+        "collections-publisher",
+        "smartanswers",
+        "publisher",
+        "feedback",
+        "contacts",
+        "design-principles",
+        "specialist-publisher",
+        "travel-advice-publisher",
+        "policy-publisher",
+        "manuals-frontend",
+        "hmrc-manuals-api",
+        "share-sale-publisher",
+        "service-manual-publisher"
+      ],
+      "rendering_apps": [
+        null
+      ],
+      "examples": [
+        "/16-to-18-education-free-meals",
+        "/16-to-18-residential-bursary-fund",
+        "/16-to-18-residential-support-scheme",
+        "/16-to-19-bursary-fund-guide-for-2015-to-2016",
+        "/16-to-19-capital-funding",
+        "/16-to-19-education-accountability",
+        "/16-to-19-education-commercial-and-charitable-providers",
+        "/16-to-19-education-financial-management-and-assurance",
+        "/16-to-19-education-financial-support-for-students",
+        "/16-to-19-education-funding-allocations"
+      ]
+    },
+    {
+      "name": "programme",
+      "count": 57,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/1619-bursary-fund",
+        "/access-to-elected-office-fund",
+        "/adult-dependants-grant",
+        "/agricultural-sick-pay",
+        "/apply-for-student-finance-2012-13",
+        "/asylum-support",
+        "/attendance-allowance",
+        "/bereavement-allowance",
+        "/bereavement-payment",
+        "/blind-persons-allowance"
+      ]
+    },
+    {
+      "name": "gone",
+      "count": 398,
+      "schema_names": [
+        "gone"
+      ],
+      "publishing_apps": [
+        "specialist-publisher",
+        "content-tagger",
+        "external-link-tracker",
+        "whitehall",
+        "contacts",
+        "policy-publisher",
+        "manuals-frontend",
+        "hmrc-manuals-api"
+      ],
+      "rendering_apps": [
+        null
+      ],
+      "examples": [
+        "/aaib-reports/aar-4-2010-boeing-777-236-g-viir-26-september-2009",
+        "/aaib-reports/aaib-investigation-to-piper-pa-38-112-tomahawk-g-bnde-correction",
+        "/alpha-taxonomy/76e54ecc-72a3-438d-8331-8c055d8b823d-providing-childcare",
+        "/cma-cases/arriva-passenger-services-limited-centrebus-holdings-limited",
+        "/cma-cases/bank-of-montreal-f-c-asset-management-limited",
+        "/cma-cases/ca98-and-cartels-cases-before-1-april-2014",
+        "/cma-cases/care-monitoring-management-panztel",
+        "/cma-cases/criminal-cartels-cases-before-1-april-2014",
+        "/cma-cases/diageo-plc-united-spirits-limited",
+        "/cma-cases/energy-price-control-appeals-northern-powergrid-and-british-gas-trading"
+      ]
+    },
+    {
+      "name": "finder",
+      "count": 14,
+      "schema_names": [
+        "finder"
+      ],
+      "publishing_apps": [
+        "specialist-publisher",
+        "policy-publisher"
+      ],
+      "rendering_apps": [
+        "finder-frontend"
+      ],
+      "examples": [
+        "/aaib-reports",
+        "/cma-cases",
+        "/countryside-stewardship-grants",
+        "/dfid-research-outputs",
+        "/drug-device-alerts",
+        "/drug-safety-update",
+        "/european-structural-investment-funds",
+        "/government/policies",
+        "/government/policies/all",
+        "/international-development-funding"
+      ]
+    },
+    {
+      "name": "aaib_report",
+      "count": 9938,
+      "schema_names": [
+        "specialist_document",
+        "placeholder_specialist_document"
+      ],
+      "publishing_apps": [
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "specialist-frontend"
+      ],
+      "examples": [
+        "/aaib-reports/1-1971-g-atek-and-g-ateh-15-august-1967",
+        "/aaib-reports/1-1972-g-apdn-3-july-1970",
+        "/aaib-reports/1-1973-ph-moa-3-june-1971",
+        "/aaib-reports/1-1974-n-801-wa-and-oo-srg-12-march-1973",
+        "/aaib-reports/1-1975-beechcraft-95-b55-baron-g-azzj-4-january-1974",
+        "/aaib-reports/1-1976-sikorsky-s-67-blackhawk-n671sa-1-september-1974",
+        "/aaib-reports/1-1977-hawker-siddeley-hs-125-series-600b-g-bcux-20-november-1975",
+        "/aaib-reports/1-1978-bell-206-jet-ranger-g-baya-11-january-1977",
+        "/aaib-reports/1-1979-piper-pa32r-cherokee-lance-ph-ply-29-april-1978",
+        "/aaib-reports/1-1980-strojirni-prvni-potiletky-super-aero-145-g-asws-9-july-1978"
+      ]
+    },
+    {
+      "name": "specialist_document",
+      "count": 1,
+      "schema_names": [
+        "specialist_document"
+      ],
+      "publishing_apps": [
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "specialist-frontend"
+      ],
+      "examples": [
+        "/aaib-reports/aaib-investigation-to-folland-gnat-t-mk-1-g-timm"
+      ]
+    },
+    {
+      "name": "answer",
+      "count": 768,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/acas",
+        "/accepting-returns-and-giving-refunds",
+        "/accidents-at-work",
+        "/acoustic-neuroma-and-driving",
+        "/add-to-energy-technology-list",
+        "/adding-fathers-name-birth-certificate",
+        "/adding-higher-categories-to-your-driving-licence",
+        "/addisons-disease-driving",
+        "/adhd-and-driving",
+        "/ads-visa"
+      ]
+    },
+    {
+      "name": "transaction",
+      "count": 314,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/accelerated-possession-eviction",
+        "/adi-criminal-record-disclosure",
+        "/advertise-internship",
+        "/advertise-job",
+        "/agricultural-survey",
+        "/anfonwch-rhent-prydles-manylion",
+        "/animal-disease-testing",
+        "/appeal-planning-inspectorate",
+        "/apply-become-lgv-driving-instructor",
+        "/apply-blue-badge"
+      ]
+    },
+    {
+      "name": "placeholder",
+      "count": 4226,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher",
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "frontend",
+        "whitehall-frontend",
+        "whitehall"
+      ],
+      "examples": [
+        "/access-finance-hbv-loan-funds",
+        "/advanced-learning-loans",
+        "/alcohol-and-tobacco-excise-duty",
+        "/amusement-machine-licence-all-uk",
+        "/appeal-school-admission-decision",
+        "/apply-for-a-dispensation",
+        "/apply-for-a-vehicle-identity-check-vic",
+        "/apply-for-an-eu-ecolabel",
+        "/apply-for-tax-disc-in-advance",
+        "/apply-growth-vouchers"
+      ]
+    },
+    {
+      "name": "guide",
+      "count": 729,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/access-to-work",
+        "/additional-state-pension",
+        "/adi-part-1-test",
+        "/adi-part-2-test",
+        "/adi-part-3-test",
+        "/adi-standards-check",
+        "/administrative-appeals-tribunal",
+        "/adoption-pay-leave",
+        "/adoption-records",
+        "/advanced-learner-loan"
+      ]
+    },
+    {
+      "name": "campaign",
+      "count": 47,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/accessiblebritain",
+        "/britainisgreat",
+        "/careandsupport",
+        "/childcaresupport",
+        "/choicenotchance",
+        "/creditcardsales",
+        "/disability-confident",
+        "/dla-ending",
+        "/dotherightthing",
+        "/fakemeds"
+      ]
+    },
+    {
+      "name": "licence",
+      "count": 508,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/accredited-electrical-and-electronic-equipment-producer-compliance-scheme-scotland",
+        "/actuaries-england-scotland-wales",
+        "/adult-placement-services-registration-england",
+        "/adult-placement-services-registration-northern-ireland",
+        "/adult-placement-services-registration-scotland",
+        "/adventure-activities-licence",
+        "/air-conditioning-energy-assessor-accreditation-northern-ireland",
+        "/air-conditioning-system-energy-assessor-accreditation-england-wales",
+        "/air-travel-organisers-licence",
+        "/aircraft-maintenance-engineering-licence"
+      ]
+    },
+    {
+      "name": "smartanswer_document",
+      "count": 38,
+      "schema_names": [
+        "placeholder_smart_answer"
+      ],
+      "publishing_apps": [
+        "smartanswers"
+      ],
+      "rendering_apps": [
+        "smartanswers"
+      ],
+      "examples": [
+        "/additional-commodity-code",
+        "/am-i-getting-minimum-wage",
+        "/benefit-cap-calculator",
+        "/calculate-agricultural-holiday-entitlement",
+        "/calculate-employee-redundancy-pay",
+        "/calculate-married-couples-allowance",
+        "/calculate-statutory-sick-pay",
+        "/calculate-your-child-maintenance",
+        "/calculate-your-holiday-entitlement",
+        "/calculate-your-redundancy-pay"
+      ]
+    },
+    {
+      "name": "local_transaction",
+      "count": 130,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/after-school-holiday-club",
+        "/alcohol-licence-your-area",
+        "/appeal-council-housing-decision",
+        "/appeal-housing-benefit-decision",
+        "/appeal-parking-fine",
+        "/apply-allotment",
+        "/apply-building-regulation-approval-from-council",
+        "/apply-council-tax-reduction",
+        "/apply-direct-payments",
+        "/apply-disabled-facilities-grant"
+      ]
+    },
+    {
+      "name": "taxon",
+      "count": 211,
+      "schema_names": [
+        "taxon"
+      ],
+      "publishing_apps": [
+        "content-tagger"
+      ],
+      "rendering_apps": [
+        "collections"
+      ],
+      "examples": [
+        "/alpha-taxonomy/00fde028-d712-4a7c-8e69-d79615c682ef-personal-social-health-and-economic-education",
+        "/alpha-taxonomy/0134a7b5-c41a-4b42-bd0d-a7535777978e-financial-help-for-parents-getting-back-into-education",
+        "/alpha-taxonomy/05aefd16-99ac-4d76-87c4-54c4123b3012-early-years-curriculum-0-to-5",
+        "/alpha-taxonomy/073fc305-423a-41e0-9b1a-c7305a0e222f-education-general",
+        "/alpha-taxonomy/0b0f664c-e4e9-4b84-8788-c76323cc93a7-inspection-and-performance-of-further-education-providers",
+        "/alpha-taxonomy/0dc08dc0-7d45-435e-bac8-116980eaecfd-teacher-pensions",
+        "/alpha-taxonomy/11279afa-cd1f-4f38-9d6b-edbb80e177ec-changing-the-status-of-a-school",
+        "/alpha-taxonomy/14-to-19-years",
+        "/alpha-taxonomy/16bccbf0-4bdb-4454-b957-2f0658c74112-admissions-and-census-data-for-childcare-providers",
+        "/alpha-taxonomy/19874844-827f-4cbb-9451-0d63f81a982c-religious-education"
+      ]
+    },
+    {
+      "name": "video",
+      "count": 10,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/avoid-business-cashflow-problems",
+        "/business-knowledge-management",
+        "/business-selling-customers",
+        "/choosing-your-business-premises",
+        "/forecast-business-finances",
+        "/market-research-business",
+        "/renting-buying-business-premises",
+        "/understand-business-cash-flow",
+        "/understanding-business-it-needs",
+        "/what-is-corporation-tax"
+      ]
+    },
+    {
+      "name": "placeholder_calendar",
+      "count": 2,
+      "schema_names": [
+        "placeholder_calendar"
+      ],
+      "publishing_apps": [
+        "calendars"
+      ],
+      "rendering_apps": [
+        "calendars"
+      ],
+      "examples": [
+        "/bank-holidays",
+        "/when-do-the-clocks-change"
+      ]
+    },
+    {
+      "name": "simple_smart_answer",
+      "count": 27,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/become-a-driving-instructor",
+        "/become-motorcycle-instructor",
+        "/biometric-data-records",
+        "/check-british-citizen",
+        "/check-if-you-need-a-tax-return",
+        "/claim-national-insurance-refund",
+        "/claim-state-pension-online",
+        "/contact-dvsa",
+        "/contact-the-dvla",
+        "/driving-nongb-licence"
+      ]
+    },
+    {
+      "name": "mainstream_browse_page",
+      "count": 151,
+      "schema_names": [
+        "mainstream_browse_page"
+      ],
+      "publishing_apps": [
+        "collections-publisher"
+      ],
+      "rendering_apps": [
+        "collections"
+      ],
+      "examples": [
+        "/browse",
+        "/browse/abroad",
+        "/browse/abroad/living-abroad",
+        "/browse/abroad/passports",
+        "/browse/abroad/travel-abroad",
+        "/browse/benefits",
+        "/browse/benefits/bereavement",
+        "/browse/benefits/child",
+        "/browse/benefits/disability",
+        "/browse/benefits/entitlement"
+      ]
+    },
+    {
+      "name": "placeholder_business_support_finder",
+      "count": 1,
+      "schema_names": [
+        "placeholder_business_support_finder"
+      ],
+      "publishing_apps": [
+        "businesssupportfinder"
+      ],
+      "rendering_apps": [
+        "businesssupportfinder"
+      ],
+      "examples": [
+        "/business-finance-support-finder"
+      ]
+    },
+    {
+      "name": "calculator_document",
+      "count": 1,
+      "schema_names": [
+        "placeholder_calculator"
+      ],
+      "publishing_apps": [
+        "calculators"
+      ],
+      "rendering_apps": [
+        "calculators"
+      ],
+      "examples": [
+        "/child-benefit-tax-calculator"
+      ]
+    },
+    {
+      "name": "cma_case",
+      "count": 1782,
+      "schema_names": [
+        "specialist_document",
+        "placeholder_specialist_document"
+      ],
+      "publishing_apps": [
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "specialist-frontend"
+      ],
+      "examples": [
+        "/cma-cases/-allflex-holding-france-alfred-cox-merger-inquiry",
+        "/cma-cases/-enviva-holdings-lp-green-circle-bio-energy-inc",
+        "/cma-cases/-prosecution-for-suspected-fraud-in-property-sales",
+        "/cma-cases/-reckitt-benckiser-johnson-johnson",
+        "/cma-cases/2-sisters-storteboom-group",
+        "/cma-cases/3i-group-plc-shearings-group-holdings-ltd",
+        "/cma-cases/3i-group-plc-uponor-ltd",
+        "/cma-cases/3m-company-biotrace-international-plc",
+        "/cma-cases/3m-united-kingdom-plc-vantage-health-ltd",
+        "/cma-cases/a-g-barr-britivic-plc-oft"
+      ]
+    },
+    {
+      "name": "finder_email_signup",
+      "count": 8,
+      "schema_names": [
+        "finder_email_signup"
+      ],
+      "publishing_apps": [
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "finder-frontend"
+      ],
+      "examples": [
+        "/cma-cases/email-signup",
+        "/dfid-research-outputs/email-signup",
+        "/drug-device-alerts/email-signup",
+        "/drug-safety-update/email-signup",
+        "/european-structural-investment-funds/email-signup",
+        "/international-development-funding/email-signup",
+        "/maib-reports/email-signup",
+        "/raib-reports/email-signup"
+      ]
+    },
+    {
+      "name": "place",
+      "count": 22,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/compulsory-basic-training-cbt-courses",
+        "/contact-local-marine-management-organisation",
+        "/enhanced-rider-scheme-trainer",
+        "/female-genital-mutilation-help-advice",
+        "/find-approved-speed-limiter-centre",
+        "/find-approved-tachograph-centre-atc",
+        "/find-atf-dvsa-test-station",
+        "/find-drink-drive-course",
+        "/find-driving-instructor-training",
+        "/find-mot-course"
+      ]
+    },
+    {
+      "name": "countryside_stewardship_grant",
+      "count": 241,
+      "schema_names": [
+        "specialist_document"
+      ],
+      "publishing_apps": [
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "specialist-frontend"
+      ],
+      "examples": [
+        "/countryside-stewardship-grants/12m-to-24m-watercourse-buffer-strip-on-cultivated-land-sw4",
+        "/countryside-stewardship-grants/4m-to-6m-buffer-strip-on-cultivated-land-sw1",
+        "/countryside-stewardship-grants/4m-to-6m-buffer-strip-on-intensive-grassland-sw2",
+        "/countryside-stewardship-grants/above-ground-tanks-rp18",
+        "/countryside-stewardship-grants/access-capital-items-ac1",
+        "/countryside-stewardship-grants/administration-of-group-managed-agreements-supplement-sp10",
+        "/countryside-stewardship-grants/anti-predator-combination-fencing-fg7",
+        "/countryside-stewardship-grants/anti-predator-temporary-electric-fencing-fg8",
+        "/countryside-stewardship-grants/arable-reversion-to-grassland-with-low-fertiliser-input-sw7",
+        "/countryside-stewardship-grants/autumn-sown-bumblebird-mix-ab16"
+      ]
+    },
+    {
+      "name": "organisation",
+      "count": 170,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/courts-tribunals/administrative-court",
+        "/courts-tribunals/chancery-division-of-the-high-court",
+        "/courts-tribunals/court-of-appeal-criminal-division",
+        "/courts-tribunals/first-tier-tribunal-special-educational-needs-and-disability",
+        "/courts-tribunals/northampton-county-court-business-centre",
+        "/courts-tribunals/queens-bench-division-of-the-high-court",
+        "/government/organisations/acas",
+        "/government/organisations/advisory-council-on-the-misuse-of-drugs",
+        "/government/organisations/air-accidents-investigation-branch",
+        "/government/organisations/animal-and-plant-health-agency"
+      ]
+    },
+    {
+      "name": "placeholder_organisation",
+      "count": 848,
+      "schema_names": [
+        "placeholder_organisation"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/courts-tribunals/admiralty-court",
+        "/courts-tribunals/bankruptcy-court",
+        "/courts-tribunals/commercial-court",
+        "/courts-tribunals/companies-court",
+        "/courts-tribunals/court-of-appeal-civil-division",
+        "/courts-tribunals/court-of-protection",
+        "/courts-tribunals/employment-appeal-tribunal",
+        "/courts-tribunals/employment-tribunal",
+        "/courts-tribunals/family-division-of-the-high-court",
+        "/courts-tribunals/first-tier-tribunal-asylum-support"
+      ]
+    },
+    {
+      "name": "dfid_research_output",
+      "count": 30162,
+      "schema_names": [
+        "specialist_document"
+      ],
+      "publishing_apps": [
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "specialist-frontend"
+      ],
+      "examples": [
+        "/dfid-research-outputs/1-1-report-on-irrigated-rice-marketing-in-ghana-december-1996-natural-resources-institute-nri-university-of-greenwich-uk",
+        "/dfid-research-outputs/1-2-analysis-of-rice-marketing-in-northern-ghana-march-1997-natural-resources-institute-nri-university-of-greenwich-uk-part-1",
+        "/dfid-research-outputs/1-3-marketing-of-rice-in-the-inland-valleys-of-southern-ghana-october-1997-natural-resources-institute-nri-university-of-greenwich-uk",
+        "/dfid-research-outputs/1-aryl-4-nitro-1-i-h-i-imidazoles-a-new-promising-series-for-the-treatment-of-human-african-trypanosomiasis",
+        "/dfid-research-outputs/1-introduction-the-plant-animal-interface-in-a-systems-concept-pp-495-542-in-13-the-plant-animal-interface-in-models-of-grazing-systems-university-of-edinburgh-uk",
+        "/dfid-research-outputs/1-marketing-of-rice-in-ghana-part-1-appendices-natural-resources-institute-nri-university-of-greenwich-uk",
+        "/dfid-research-outputs/1-marketing-of-rice-in-ghana-part-1-natural-resources-institute-nri-university-of-greenwich-uk",
+        "/dfid-research-outputs/1-year-after-the-lancet-neonatal-survival-series-was-the-call-for-action-heard",
+        "/dfid-research-outputs/10-best-resources-in-cost-analysis-for-hiv-aids-programmes-in-low-and-middle-income-countries",
+        "/dfid-research-outputs/10-best-resources-on-intersectionality-with-an-emphasis-on-low-and-middle-income-countries"
+      ]
+    },
+    {
+      "name": "completed_transaction",
+      "count": 129,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/done-apply-queens-award-enterprise",
+        "/done/accelerated-possession-eviction",
+        "/done/animal-disease-testing",
+        "/done/apply-apprenticeship",
+        "/done/apply-carers-allowance",
+        "/done/apply-civil-service-apprenticeship",
+        "/done/apply-civil-service-fast-stream",
+        "/done/apply-employment-tribunal",
+        "/done/apply-faster-entry-usa",
+        "/done/apply-queens-award-enterprise"
+      ]
+    },
+    {
+      "name": "medical_safety_alert",
+      "count": 373,
+      "schema_names": [
+        "specialist_document",
+        "placeholder_specialist_document"
+      ],
+      "publishing_apps": [
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "specialist-frontend"
+      ],
+      "examples": [
+        "/drug-device-alerts/-estradiol-immunoassays-interference-from-the-drug-fulvestrant-faslodex-may-cause-falsely-elevated-estradiol-results",
+        "/drug-device-alerts/-medical-device-alert-external-temporary-cardiac-pacemaker-bedside-model-4170-serial-numbers-1-998-return-these-to-manufacturer-and-ensure-rapid-pace-switch-is-off-before-you-shut-the-device-down",
+        "/drug-device-alerts/-medical-device-alert-sprint-fidelis-implantable-cardioverter-defibrillator-icd-lead-reports-of-lead-conductor-fracture",
+        "/drug-device-alerts/accu-chek-insight-insulin-pump-system-manufactured-by-roche-diabetes-care-risk-of-inappropriate-treatment",
+        "/drug-device-alerts/accu-chek-insight-insulin-pump-system-manufactured-by-roche-diabetes-care-with-novorapid-pumpcart-cartridges-risk-of-hyperglycaemia",
+        "/drug-device-alerts/accu-chek-insight-insulin-pump-system-risk-of-over-or-under-infusion-of-insulin",
+        "/drug-device-alerts/accu-chek-mobile-meter-and-accu-chek-mobile-test-cassette-risk-of-falsely-high-readings-if-testing-procedure-is-not-followed",
+        "/drug-device-alerts/adalat-la-60mg-tablets-incorrectly-packaged-in-30mg-carton-clda-16-a-08",
+        "/drug-device-alerts/airvo-2-and-myairvo-2-humidifier-risk-of-undetected-auditory-alarm",
+        "/drug-device-alerts/all-accu-chek-insight-insulin-pumps-risk-of-hyperglycaemia-from-rapid-pump-battery-depletion-or-unexpected-shut-down"
+      ]
+    },
+    {
+      "name": "drug_safety_update",
+      "count": 415,
+      "schema_names": [
+        "specialist_document"
+      ],
+      "publishing_apps": [
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "specialist-frontend"
+      ],
+      "examples": [
+        "/drug-safety-update/-1-adrenoreceptor-antagonists-intraoperative-floppy-iris-syndrome-ifis",
+        "/drug-safety-update/-dextro-propoxyphene-new-studies-confirm-cardiac-risks",
+        "/drug-safety-update/-first-steps-infant-medicine-feeder-recall-due-to-overdose-risk",
+        "/drug-safety-update/-letters-sent-to-healthcare-professionals-in-july-2015",
+        "/drug-safety-update/abacavir-risk-of-myocardial-infarction-update-from-epidemiological-studies",
+        "/drug-safety-update/abraxane-paclitaxel-formulated-as-albumin-bound-nanoparticles-potential-presence-of-strands-in-intravenous-infusion-bag",
+        "/drug-safety-update/ace-inhibitors-and-angiotensin-ii-receptor-antagonists-not-for-use-in-pregnancy",
+        "/drug-safety-update/ace-inhibitors-and-angiotensin-ii-receptor-antagonists-recommendations-on-how-to-use-for-breastfeeding",
+        "/drug-safety-update/aceclofenac-preservex-updated-cardiovascular-advice-in-line-with-diclofenac-and-cox-2-inhibitors",
+        "/drug-safety-update/addiction-to-benzodiazepines-and-codeine"
+      ]
+    },
+    {
+      "name": "esi_fund",
+      "count": 432,
+      "schema_names": [
+        "specialist_document"
+      ],
+      "publishing_apps": [
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "specialist-frontend"
+      ],
+      "examples": [
+        "/european-structural-investment-funds/access-to-employment-and-learning-and-skills-call-in-london",
+        "/european-structural-investment-funds/access-to-employment-call-for-thames-valley-and-berkshire",
+        "/european-structural-investment-funds/access-to-employment-call-in-coventry-and-warwickshire-lep-area-oc06s16p0290",
+        "/european-structural-investment-funds/access-to-employment-call-in-coventry-and-warwickshire-lep-area-oc06s16p0291",
+        "/european-structural-investment-funds/access-to-employment-call-in-coventry-and-warwickshire-lep-area-oc06s16p0292",
+        "/european-structural-investment-funds/access-to-employment-call-in-east-of-england",
+        "/european-structural-investment-funds/access-to-employment-call-in-the-east-of-england",
+        "/european-structural-investment-funds/access-to-employment-call-in-west-midlands",
+        "/european-structural-investment-funds/access-to-employment-call-in-yorkshire-and-the-humber",
+        "/european-structural-investment-funds/access-to-employment-community-innovation-grants-project-call-in-sheffield-city-region-lep-area-oc28s16p0352"
+      ]
+    },
+    {
+      "name": "travel_advice_index",
+      "count": 1,
+      "schema_names": [
+        "travel_advice_index"
+      ],
+      "publishing_apps": [
+        "travel-advice-publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/foreign-travel-advice"
+      ]
+    },
+    {
+      "name": "travel_advice",
+      "count": 225,
+      "schema_names": [
+        "travel_advice"
+      ],
+      "publishing_apps": [
+        "travel-advice-publisher"
+      ],
+      "rendering_apps": [
+        "multipage-frontend"
+      ],
+      "examples": [
+        "/foreign-travel-advice/afghanistan",
+        "/foreign-travel-advice/albania",
+        "/foreign-travel-advice/algeria",
+        "/foreign-travel-advice/american-samoa",
+        "/foreign-travel-advice/andorra",
+        "/foreign-travel-advice/angola",
+        "/foreign-travel-advice/anguilla",
+        "/foreign-travel-advice/antigua-and-barbuda",
+        "/foreign-travel-advice/argentina",
+        "/foreign-travel-advice/armenia"
+      ]
+    },
+    {
+      "name": "email_alert_signup",
+      "count": 454,
+      "schema_names": [
+        "email_alert_signup"
+      ],
+      "publishing_apps": [
+        "travel-advice-publisher",
+        "policy-publisher",
+        "service-manual-publisher"
+      ],
+      "rendering_apps": [
+        "email-alert-frontend"
+      ],
+      "examples": [
+        "/foreign-travel-advice/afghanistan/email-signup",
+        "/foreign-travel-advice/albania/email-signup",
+        "/foreign-travel-advice/algeria/email-signup",
+        "/foreign-travel-advice/american-samoa/email-signup",
+        "/foreign-travel-advice/andorra/email-signup",
+        "/foreign-travel-advice/angola/email-signup",
+        "/foreign-travel-advice/anguilla/email-signup",
+        "/foreign-travel-advice/antigua-and-barbuda/email-signup",
+        "/foreign-travel-advice/argentina/email-signup",
+        "/foreign-travel-advice/armenia/email-signup"
+      ]
+    },
+    {
+      "name": "case_study",
+      "count": 1505,
+      "schema_names": [
+        "case_study"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "government-frontend"
+      ],
+      "examples": [
+        "/government/case-studies/2-dtech-taking-graphene-out-of-the-laboratory-into-big-business",
+        "/government/case-studies/2013-elections-in-swaziland",
+        "/government/case-studies/3-sussex-councils-save-58-on-office-supplies",
+        "/government/case-studies/3-things-nicola-did-to-go-from-jobless-to-her-own-boss",
+        "/government/case-studies/34-local-councils-save-88-million-on-it-hardware",
+        "/government/case-studies/3d-scanning-measuring-how-wounds-heal",
+        "/government/case-studies/49-million-worth-joint-research-collaborations-between-uk-india",
+        "/government/case-studies/5000-grant-helps-rypeoffice-get-low-carbon-furniture-to-market",
+        "/government/case-studies/a-biscuit-a-day",
+        "/government/case-studies/a-chance-to-grow"
+      ]
+    },
+    {
+      "name": "unpublishing",
+      "count": 3,
+      "schema_names": [
+        "unpublishing"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend",
+        "government-frontend"
+      ],
+      "examples": [
+        "/government/case-studies/bost-agri-business-park-a-beacon-for-business-potential",
+        "/government/case-studies/stuart-scott",
+        "/government/case-studies/troubled-families-dudley"
+      ]
+    },
+    {
+      "name": "coming_soon",
+      "count": 130,
+      "schema_names": [
+        "coming_soon"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "government-frontend",
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/case-studies/ww1-australian-vc-recipient-corporal-alexander-stewart-burton",
+        "/government/news/cork-popping-success-of-english-and-welsh-sparkling-wines",
+        "/government/news/cork-popping-success-of-english-sparkling-wines",
+        "/government/news/new-ofcom-chair-appointed--2",
+        "/government/publications/community-lenders-and-social-investment",
+        "/government/publications/ninth-statement-of-new-regulations-better-regulation-executive",
+        "/government/statistics/2011-census-analysis-economic-expectancies-for-english-upper-tier-local-authorities-and-welsh-unitary-authorities",
+        "/government/statistics/accommodation-bedstock-in-wales-2014",
+        "/government/statistics/annual-business-survey-2013-regional-results",
+        "/government/statistics/annual-business-survey-2013-revised-results"
+      ]
+    },
+    {
+      "name": "document_collection",
+      "count": 3729,
+      "schema_names": [
+        "placeholder_document_collection"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/collections/1-october-2014-changes-to-design-and-patent-law",
+        "/government/collections/1000-series-general-regulations-gen",
+        "/government/collections/2000-series-flying-regulations-fly",
+        "/government/collections/2011-skills-for-life-survey",
+        "/government/collections/2012-olympic-and-paralympic-games-progress-of-delivery",
+        "/government/collections/2012-to-2013-pay-review-body-reports",
+        "/government/collections/2016-assessment-and-reporting-arrangements",
+        "/government/collections/201617-national-tariff-proposals",
+        "/government/collections/24-advanced-learning-loans-monthly-briefing",
+        "/government/collections/25000-spend"
+      ]
+    },
+    {
+      "name": "consultation_outcome",
+      "count": 2456,
+      "schema_names": [
+        "placeholder_consultation"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/consultations/16-to-19-accountability-consultation",
+        "/government/consultations/2010-drug-strategy-consultation-paper",
+        "/government/consultations/2015-consultation-on-capacity-market-supplementary-design-proposals-and-changes-to-the-rules-and-regulations",
+        "/government/consultations/2050-pathways-analysis",
+        "/government/consultations/21st-century-welfare",
+        "/government/consultations/25th-seaward-licensing-round",
+        "/government/consultations/26th-seaward-licensing-round",
+        "/government/consultations/27th-seaward-licensing-round",
+        "/government/consultations/28th-seaward-licensing-round-appropriate-assessments",
+        "/government/consultations/30-marginal-rate-rule-for-emergency-admissions"
+      ]
+    },
+    {
+      "name": "closed_consultation",
+      "count": 733,
+      "schema_names": [
+        "placeholder_consultation"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/consultations/2014-to-2020-european-structural-and-investment-funds-growth-programme-european-regional-development-fund-strategic-environmental-assessment",
+        "/government/consultations/28th-seaward-licensing-round",
+        "/government/consultations/30-hour-free-childcare-entitlement",
+        "/government/consultations/a-bank-levy-banding-approach",
+        "/government/consultations/a-call-for-evidence-on-barriers-to-securing-long-term-contracts-for-independent-renewable-generation-investment",
+        "/government/consultations/a-new-approach-to-financial-regulation-the-blueprint-for-reform",
+        "/government/consultations/a-new-era-for-the-waterways",
+        "/government/consultations/a-new-strategy-for-sport-consultation",
+        "/government/consultations/a-review-of-the-corporate-insolvency-framework",
+        "/government/consultations/a-simplified-further-education-and-skills-funding-system-and-methodology"
+      ]
+    },
+    {
+      "name": "open_consultation",
+      "count": 227,
+      "schema_names": [
+        "placeholder_consultation"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/consultations/2018-periodic-review-initial",
+        "/government/consultations/5g-call-for-evidence",
+        "/government/consultations/a1-birtley-to-coal-house-improvement-scheme-options",
+        "/government/consultations/a27-chichester-bypass-improvement-scheme",
+        "/government/consultations/a585-windy-harbour-to-skippool-improvements",
+        "/government/consultations/accelerated-courses-and-switching-university-or-degree-call-for-evidence",
+        "/government/consultations/advanced-driver-assistance-systems-and-automated-vehicle-technologies-supporting-their-use-in-the-uk",
+        "/government/consultations/aggregates-levy-whether-to-exempt-aggregate-extracted-when-laying-underground-utility-pipes",
+        "/government/consultations/alignment-of-dates-for-making-good-on-benefits-in-kind",
+        "/government/consultations/allowing-vessels-targeting-plaice-in-the-north-sea-to-use-tr1-gears"
+      ]
+    },
+    {
+      "name": "html_publication",
+      "count": 13777,
+      "schema_names": [
+        "html_publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/consultations/5g-call-for-evidence/5g-call-for-evidence",
+        "/government/consultations/amending-the-definition-of-financial-advice-consultation/amending-the-definition-of-financial-advice-consultation",
+        "/government/consultations/bail-in-powers-implementation-including-draft-secondary-legislation/bail-in-powers-implementation",
+        "/government/consultations/banking-reform-draft-pensions-regulations/banking-reform-draft-pensions-regulations",
+        "/government/consultations/british-credit-unions-at-50-call-for-evidence/call-for-evidence-british-credit-unions-at-50",
+        "/government/consultations/call-for-information-anti-money-laundering-supervisory-regime/call-for-information-anti-money-laundering-supervisory-regime",
+        "/government/consultations/cambridge-milton-keynes-oxford-growth-corridor-call-for-evidence/cambridge-milton-keynes-oxford-growth-corridor-call-for-evidence",
+        "/government/consultations/changing-how-healthcare-education-is-funded/the-case-for-health-education-funding-reform",
+        "/government/consultations/communications-for-people-who-are-deaf-or-have-hearing-loss-communications-support-work/call-for-evidence-market-review-of-bsl-and-communications-provision-for-people-who-are-deaf-or-have-hearing-loss-communication-support-work",
+        "/government/consultations/competition-in-banking-improving-access-to-sme-credit-data/competition-in-banking-improving-access-to-sme-credit-data"
+      ]
+    },
+    {
+      "name": "consultation",
+      "count": 5,
+      "schema_names": [
+        "placeholder_consultation"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/consultations/consultation-on-official-warnings-to-charities-and-trustees",
+        "/government/consultations/consultation-uk-market-surveillance-for-marine-equipment",
+        "/government/consultations/reform-of-the-substantial-shareholdings-exemption",
+        "/government/consultations/review-of-the-merchant-shipping-vessel-traffic-monitoring-and-reporting-requirements-amendment-regulations-2011",
+        "/government/consultations/waiting-and-loading-restrictions-required-for-developments"
+      ]
+    },
+    {
+      "name": "fatality_notice",
+      "count": 501,
+      "schema_names": [
+        "fatality_notice"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "government-frontend"
+      ],
+      "examples": [
+        "/government/fatalities/3-soldiers-of-2nd-battalion-the-royal-regiment-of-scotland-killed-in-afghanistan",
+        "/government/fatalities/acting-chief-petty-officer-simon-owen",
+        "/government/fatalities/acting-corporal-marcin-wojtak-killed-in-afghanistan",
+        "/government/fatalities/acting-corporal-richard-robbo-robinson-killed-in-helmand",
+        "/government/fatalities/acting-sergeant-michael-lockett-mc-killed-in-afghanistan",
+        "/government/fatalities/acting-serjeant-stuart-mcgrath-and-trooper-brett-hall-killed-following-incidents-in-afghanistan",
+        "/government/fatalities/bombardier-craig-hopson-killed-in-afghanistan",
+        "/government/fatalities/bombardier-samuel-joseph-robinson-killed-in-afghanistan",
+        "/government/fatalities/bombardier-stephen-gilbert-dies-of-wounds-sustained-in-afghanistan",
+        "/government/fatalities/british-officer-killed-in-iraq-major-matthew-bacon"
+      ]
+    },
+    {
+      "name": "field_of_operation",
+      "count": 5,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/fields-of-operation/afghanistan",
+        "/government/fields-of-operation/iraq",
+        "/government/fields-of-operation/northern-ireland",
+        "/government/fields-of-operation/other-locations",
+        "/government/fields-of-operation/united-kingdom"
+      ]
+    },
+    {
+      "name": "take_part",
+      "count": 18,
+      "schema_names": [
+        "take_part"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "government-frontend"
+      ],
+      "examples": [
+        "/government/get-involved/take-part/become-a-councillor",
+        "/government/get-involved/take-part/challenge-to-run-a-local-service",
+        "/government/get-involved/take-part/create-a-community-library",
+        "/government/get-involved/take-part/decide-where-new-homes-shops-facilities-and-businesses-should-be-built",
+        "/government/get-involved/take-part/help-make-your-neighbourhood-a-safer-place",
+        "/government/get-involved/take-part/help-run-a-charity",
+        "/government/get-involved/take-part/improve-your-social-housing",
+        "/government/get-involved/take-part/invest-in-local-enterprises",
+        "/government/get-involved/take-part/make-a-neighbourhood-plan",
+        "/government/get-involved/take-part/national-citizen-service"
+      ]
+    },
+    {
+      "name": "working_group",
+      "count": 664,
+      "schema_names": [
+        "working_group"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "government-frontend"
+      ],
+      "examples": [
+        "/government/groups/2gether-nhs-foundation-trust",
+        "/government/groups/4gtv-co-existence-oversight-board",
+        "/government/groups/5-boroughs-partnership-nhs-foundation-trust",
+        "/government/groups/aapb",
+        "/government/groups/abstraction-reform",
+        "/government/groups/academy-for-justice-learning-groups",
+        "/government/groups/action-group-on-cross-border-remittances",
+        "/government/groups/acumen-assessing-capturing-and-utilising-methane-from-expired-and-non-operational-landfills",
+        "/government/groups/administrative-burden-advisory-board",
+        "/government/groups/administrative-justice-advisory-group"
+      ]
+    },
+    {
+      "name": "placeholder_working_group",
+      "count": 2,
+      "schema_names": [
+        "placeholder_working_group"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/groups/funding-external-technical-advisory-group",
+        "/government/groups/military-stabilisation-support-group"
+      ]
+    },
+    {
+      "name": "placeholder_ministerial_role",
+      "count": 121,
+      "schema_names": [
+        "placeholder_ministerial_role"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/ministers/assistant-government-whip",
+        "/government/ministers/assistant-government-whip--14",
+        "/government/ministers/assistant-government-whip--2",
+        "/government/ministers/assistant-government-whip--3",
+        "/government/ministers/assistant-government-whip--4",
+        "/government/ministers/assistant-government-whip--5",
+        "/government/ministers/assistant-government-whip--6",
+        "/government/ministers/assistant-whip",
+        "/government/ministers/assistant-whip--2",
+        "/government/ministers/baroness-northover"
+      ]
+    },
+    {
+      "name": "ministerial_role",
+      "count": 168,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/ministers/assistant-government-whip--10",
+        "/government/ministers/assistant-government-whip--11",
+        "/government/ministers/assistant-government-whip--12",
+        "/government/ministers/assistant-government-whip--13",
+        "/government/ministers/assistant-government-whip--15",
+        "/government/ministers/assistant-government-whip--7",
+        "/government/ministers/assistant-government-whip--8",
+        "/government/ministers/assistant-government-whip--9",
+        "/government/ministers/attorney-general",
+        "/government/ministers/baroness-in-waiting-government-whip"
+      ]
+    },
+    {
+      "name": "announcement",
+      "count": 10443,
+      "schema_names": [
+        "placeholder_news_article"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/news/007-joins-uk-forces-in-afghanistan-for-skyfall-screening",
+        "/government/news/073-2012-ministry-of-defence-appoints-new-chief-scientific-adviser",
+        "/government/news/074-2012-diamond-flypast-for-the-queen",
+        "/government/news/077-2012-star-of-jubilee-celebrations-deploys-to-gulf",
+        "/government/news/078-2012-ministry-of-defence-permanent-secretary-moves-on",
+        "/government/news/079-2012-celebrating-fathers-day-in-afghanistan",
+        "/government/news/080-2012-hammond-announces-1billion-contract-to-power-future-submarines",
+        "/government/news/081-2012-army-s-new-foxhound-vehicle-is-put-on-display",
+        "/government/news/082-2012-ice-ship-snapper-wins-royal-navy-competition-in-50th-year",
+        "/government/news/083-2012-flags-raised-across-the-world-for-the-armed-forces"
+      ]
+    },
+    {
+      "name": "news_story",
+      "count": 20650,
+      "schema_names": [
+        "placeholder_news_article"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/news/1-2-billion-contract-awarded-for-new-attack-submarine",
+        "/government/news/1-7-million-gold-standard-sets-new-homelessness-benchmark",
+        "/government/news/1-april-2015-update-to-the-patent-cooperation-treaty-pct-fees",
+        "/government/news/1-billion-contract-to-develop-cutting-edge-radar-for-typhoon",
+        "/government/news/1-billion-extra-funding-for-schools-in-england",
+        "/government/news/1-billion-growth-fund-boost-open-for-business--2",
+        "/government/news/1-billion-payout-for-equitable-life-policyholders",
+        "/government/news/1-january-2016-update-to-the-patent-cooperation-treaty-pct-fees",
+        "/government/news/1-july-2016-update-to-the-patent-cooperation-treaty-pct-fees",
+        "/government/news/1-june-2015-update-to-the-patent-cooperation-treaty-pct-fees"
+      ]
+    },
+    {
+      "name": "press_release",
+      "count": 22299,
+      "schema_names": [
+        "placeholder_news_article"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/news/1-3-million-government-pledge-to-protect-our-most-endangered-species",
+        "/government/news/1-5m-available-for-people-to-spend-on-own-care",
+        "/government/news/1-8-million-for-fairer-funding-for-end-of-life-care",
+        "/government/news/1-billion-boost-for-cambridgeshire",
+        "/government/news/1-billion-exports-win-for-uk-education-in-saudi-arabia",
+        "/government/news/1-billion-fund-to-help-regional-business",
+        "/government/news/1-billion-fund-to-help-regional-business--2",
+        "/government/news/1-billion-fund-to-help-regional-business--3",
+        "/government/news/1-billion-package-to-tackle-youth-unemployment",
+        "/government/news/1-billion-to-help-aes-and-nhs-staff-access-medical-records-in-hi-tech-hospital-revolution"
+      ]
+    },
+    {
+      "name": "government_response",
+      "count": 436,
+      "schema_names": [
+        "placeholder_news_article"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/news/2013-budget-statement-justine-greenings-comments",
+        "/government/news/a-dark-week-for-football-but-a-great-one-for-british-journalism",
+        "/government/news/a-thousand-days-to-reach-the-millennium-development-goals",
+        "/government/news/abortion-services-in-conflict-situations",
+        "/government/news/access-to-psychological-therapies-campaign",
+        "/government/news/accounting-standards-are-part-of-legally-binding-corporate-reporting-framework",
+        "/government/news/aid-in-fragile-states",
+        "/government/news/air-quality-and-highways-agency-road-schemes",
+        "/government/news/animal-aid-abattoir-cruelty-footage-myth-busted",
+        "/government/news/animal-welfare-myths-busted"
+      ]
+    },
+    {
+      "name": "about",
+      "count": 1550,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/academy-for-justice-commissioning/about",
+        "/government/organisations/acas/about",
+        "/government/organisations/accelerated-access-review/about",
+        "/government/organisations/administration-of-radioactive-substances-advisory-committee/about",
+        "/government/organisations/administrative-court/about",
+        "/government/organisations/administrative-justice-and-tribunals-council-welsh-committee/about",
+        "/government/organisations/administrative-justice-and-tribunals-council/about",
+        "/government/organisations/admiralty-court/about",
+        "/government/organisations/adult-learning-inspectorate/about",
+        "/government/organisations/advantage-west-midlands/about"
+      ]
+    },
+    {
+      "name": "about_our_services",
+      "count": 29,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/academy-for-justice-commissioning/about/about-our-services",
+        "/government/organisations/animal-and-plant-health-agency/about/about-our-services",
+        "/government/organisations/attorney-generals-office/about/about-our-services",
+        "/government/organisations/companies-house/about/about-our-services",
+        "/government/organisations/criminal-injuries-compensation-authority/about/about-our-services",
+        "/government/organisations/defence-electronics-and-components-agency/about/about-our-services",
+        "/government/organisations/department-for-international-trade/about/about-our-services",
+        "/government/organisations/district-valuer-services-dvs/about/about-our-services",
+        "/government/organisations/driver-and-vehicle-licensing-agency/about/about-our-services",
+        "/government/organisations/driver-and-vehicle-standards-agency/about/about-our-services"
+      ]
+    },
+    {
+      "name": "membership",
+      "count": 36,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/academy-for-justice-commissioning/about/membership",
+        "/government/organisations/accelerated-access-review/about/membership",
+        "/government/organisations/administration-of-radioactive-substances-advisory-committee/about/membership",
+        "/government/organisations/advisory-council-on-the-misuse-of-drugs/about/membership",
+        "/government/organisations/animals-in-science-committee/about/membership",
+        "/government/organisations/british-hallmarking-council/about/membership",
+        "/government/organisations/building-regulations-advisory-committee/about/membership",
+        "/government/organisations/central-arbitration-committee/about/membership",
+        "/government/organisations/commission-on-human-medicines/about/membership",
+        "/government/organisations/committee-on-fuel-poverty/about/membership"
+      ]
+    },
+    {
+      "name": "our_governance",
+      "count": 111,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/academy-for-justice-commissioning/about/our-governance",
+        "/government/organisations/accelerated-access-review/about/our-governance",
+        "/government/organisations/advisory-committee-on-clinical-excellence-awards/about/our-governance",
+        "/government/organisations/advisory-committee-on-releases-to-the-environment/about/our-governance",
+        "/government/organisations/advisory-group-on-military-medicine/about/our-governance",
+        "/government/organisations/animal-and-plant-health-agency/about/our-governance",
+        "/government/organisations/armed-forces-pay-review-body/about/our-governance",
+        "/government/organisations/attorney-generals-office/about/our-governance",
+        "/government/organisations/better-regulation-delivery-office/about/our-governance",
+        "/government/organisations/centre-for-environment-fisheries-and-aquaculture-science/about/our-governance"
+      ]
+    },
+    {
+      "name": "terms_of_reference",
+      "count": 38,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/accelerated-access-review/about/terms-of-reference",
+        "/government/organisations/advisory-committee-on-clinical-excellence-awards/about/terms-of-reference",
+        "/government/organisations/advisory-committee-on-releases-to-the-environment/about/terms-of-reference",
+        "/government/organisations/advisory-council-on-the-misuse-of-drugs/about/terms-of-reference",
+        "/government/organisations/airports-commission/about/terms-of-reference",
+        "/government/organisations/building-regulations-advisory-committee/about/terms-of-reference",
+        "/government/organisations/commission-on-human-medicines/about/terms-of-reference",
+        "/government/organisations/committee-on-fuel-poverty/about/terms-of-reference",
+        "/government/organisations/committee-on-mutagenicity-of-chemicals-in-food-consumer-products-and-the-environment/about/terms-of-reference",
+        "/government/organisations/committee-on-radioactive-waste-management/about/terms-of-reference"
+      ]
+    },
+    {
+      "name": "complaints_procedure",
+      "count": 225,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/advisory-committee-on-business-appointments/about/complaints-procedure",
+        "/government/organisations/advisory-group-on-military-medicine/about/complaints-procedure",
+        "/government/organisations/air-accidents-investigation-branch/about/complaints-procedure",
+        "/government/organisations/animal-and-plant-health-agency/about/complaints-procedure",
+        "/government/organisations/attorney-generals-office/about/complaints-procedure",
+        "/government/organisations/better-regulation-delivery-office/about/complaints-procedure",
+        "/government/organisations/bona-vacantia/about/complaints-procedure",
+        "/government/organisations/border-force/about/complaints-procedure",
+        "/government/organisations/cabinet-office/about/complaints-procedure",
+        "/government/organisations/central-arbitration-committee/about/complaints-procedure"
+      ]
+    },
+    {
+      "name": "personal_information_charter",
+      "count": 83,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/advisory-committee-on-business-appointments/about/personal-information-charter",
+        "/government/organisations/animal-and-plant-health-agency/about/personal-information-charter",
+        "/government/organisations/attorney-generals-office/about/personal-information-charter",
+        "/government/organisations/cabinet-office/about/personal-information-charter",
+        "/government/organisations/central-arbitration-committee/about/personal-information-charter",
+        "/government/organisations/certification-officer/about/personal-information-charter",
+        "/government/organisations/charity-commission/about/personal-information-charter",
+        "/government/organisations/civil-nuclear-constabulary/about/personal-information-charter",
+        "/government/organisations/companies-house/about/personal-information-charter",
+        "/government/organisations/competition-and-markets-authority/about/personal-information-charter"
+      ]
+    },
+    {
+      "name": "publication_scheme",
+      "count": 87,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/advisory-committee-on-business-appointments/about/publication-scheme",
+        "/government/organisations/advisory-committee-on-releases-to-the-environment/about/publication-scheme",
+        "/government/organisations/advisory-council-on-the-misuse-of-drugs/about/publication-scheme",
+        "/government/organisations/animal-and-plant-health-agency/about/publication-scheme",
+        "/government/organisations/armed-forces-pay-review-body/about/publication-scheme",
+        "/government/organisations/attorney-generals-office/about/publication-scheme",
+        "/government/organisations/bona-vacantia/about/publication-scheme",
+        "/government/organisations/british-hallmarking-council/about/publication-scheme",
+        "/government/organisations/building-regulations-advisory-committee/about/publication-scheme",
+        "/government/organisations/cabinet-office/about/publication-scheme"
+      ]
+    },
+    {
+      "name": "recruitment",
+      "count": 309,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/air-accidents-investigation-branch/about/recruitment",
+        "/government/organisations/animal-and-plant-health-agency/about/recruitment",
+        "/government/organisations/better-regulation-delivery-office/about/recruitment",
+        "/government/organisations/cabinet-office/about/recruitment",
+        "/government/organisations/civil-nuclear-constabulary/about/recruitment",
+        "/government/organisations/civil-service-government-legal-service/about/recruitment",
+        "/government/organisations/civil-service/about/recruitment",
+        "/government/organisations/commission-on-human-medicines/about/recruitment",
+        "/government/organisations/committee-on-radioactive-waste-management/about/recruitment",
+        "/government/organisations/companies-house/about/recruitment"
+      ]
+    },
+    {
+      "name": "social_media_use",
+      "count": 44,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/air-accidents-investigation-branch/about/social-media-use",
+        "/government/organisations/animal-and-plant-health-agency/about/social-media-use",
+        "/government/organisations/bona-vacantia/about/social-media-use",
+        "/government/organisations/cabinet-office/about/social-media-use",
+        "/government/organisations/companies-house/about/social-media-use",
+        "/government/organisations/criminal-injuries-compensation-authority/about/social-media-use",
+        "/government/organisations/department-for-education/about/social-media-use",
+        "/government/organisations/department-for-transport/about/social-media-use",
+        "/government/organisations/department-for-work-pensions/about/social-media-use",
+        "/government/organisations/driver-and-vehicle-licensing-agency/about/social-media-use"
+      ]
+    },
+    {
+      "name": "access_and_opening",
+      "count": 79,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/animal-and-plant-health-agency/about/access-and-opening",
+        "/government/organisations/companies-house/about/access-and-opening",
+        "/government/organisations/companies-house/about/access-and-opening.cy",
+        "/government/organisations/department-for-international-development/about/access-and-opening",
+        "/government/organisations/department-for-transport/about/access-and-opening",
+        "/government/organisations/driver-and-vehicle-standards-agency/about/access-and-opening",
+        "/government/organisations/environment-agency/about/access-and-opening",
+        "/government/organisations/highways-agency/about/access-and-opening",
+        "/government/organisations/highways-england/about/access-and-opening",
+        "/government/organisations/homes-and-communities-agency/about/access-and-opening"
+      ]
+    },
+    {
+      "name": "equality_and_diversity",
+      "count": 48,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/animal-and-plant-health-agency/about/equality-and-diversity",
+        "/government/organisations/cabinet-office/about/equality-and-diversity",
+        "/government/organisations/charity-commission/about/equality-and-diversity",
+        "/government/organisations/civil-nuclear-constabulary/about/equality-and-diversity",
+        "/government/organisations/civil-service/about/equality-and-diversity",
+        "/government/organisations/companies-house/about/equality-and-diversity",
+        "/government/organisations/companies-house/about/equality-and-diversity.cy",
+        "/government/organisations/defence-electronics-and-components-agency/about/equality-and-diversity",
+        "/government/organisations/department-for-education/about/equality-and-diversity",
+        "/government/organisations/department-for-environment-food-rural-affairs/about/equality-and-diversity"
+      ]
+    },
+    {
+      "name": "research",
+      "count": 8720,
+      "schema_names": [
+        "placeholder_corporate_information_page",
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/animal-and-plant-health-agency/about/research",
+        "/government/organisations/centre-for-environment-fisheries-and-aquaculture-science/about/research",
+        "/government/organisations/companies-house/about/research",
+        "/government/organisations/companies-house/about/research.cy",
+        "/government/organisations/department-for-business-innovation-skills/about/research",
+        "/government/organisations/department-for-culture-media-sport/about/research",
+        "/government/organisations/department-for-education/about/research",
+        "/government/organisations/department-for-environment-food-rural-affairs/about/research",
+        "/government/organisations/department-for-international-development/about/research",
+        "/government/organisations/department-for-transport/about/research"
+      ]
+    },
+    {
+      "name": "welsh_language_scheme",
+      "count": 37,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/animal-and-plant-health-agency/about/welsh-language-scheme",
+        "/government/organisations/civil-nuclear-constabulary/about/welsh-language-scheme",
+        "/government/organisations/companies-house/about/welsh-language-scheme",
+        "/government/organisations/companies-house/about/welsh-language-scheme.cy",
+        "/government/organisations/competition-and-markets-authority/about/welsh-language-scheme",
+        "/government/organisations/criminal-injuries-compensation-authority/about/welsh-language-scheme",
+        "/government/organisations/department-for-business-innovation-skills/about/welsh-language-scheme",
+        "/government/organisations/department-for-communities-and-local-government/about/welsh-language-scheme",
+        "/government/organisations/department-for-transport/about/welsh-language-scheme",
+        "/government/organisations/department-for-transport/about/welsh-language-scheme.cy"
+      ]
+    },
+    {
+      "name": "our_energy_use",
+      "count": 28,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/attorney-generals-office/about/our-energy-use",
+        "/government/organisations/cabinet-office/about/our-energy-use",
+        "/government/organisations/department-for-business-innovation-skills/about/our-energy-use",
+        "/government/organisations/department-for-communities-and-local-government/about/our-energy-use",
+        "/government/organisations/department-for-culture-media-sport/about/our-energy-use",
+        "/government/organisations/department-for-education/about/our-energy-use",
+        "/government/organisations/department-for-environment-food-rural-affairs/about/our-energy-use",
+        "/government/organisations/department-for-international-development/about/our-energy-use",
+        "/government/organisations/department-for-transport/about/our-energy-use",
+        "/government/organisations/department-for-work-pensions/about/our-energy-use"
+      ]
+    },
+    {
+      "name": "statistics",
+      "count": 37,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/attorney-generals-office/about/statistics",
+        "/government/organisations/central-arbitration-committee/about/statistics",
+        "/government/organisations/civil-service-government-legal-service/about/statistics",
+        "/government/organisations/companies-house/about/statistics",
+        "/government/organisations/companies-house/about/statistics.cy",
+        "/government/organisations/criminal-injuries-compensation-authority/about/statistics",
+        "/government/organisations/department-for-business-energy-and-industrial-strategy/about/statistics",
+        "/government/organisations/department-for-business-innovation-skills/about/statistics",
+        "/government/organisations/department-for-communities-and-local-government/about/statistics",
+        "/government/organisations/department-for-culture-media-sport/about/statistics"
+      ]
+    },
+    {
+      "name": "staff_update",
+      "count": 21,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/bank-of-england/about/staff-update",
+        "/government/organisations/defence-science-and-technology-laboratory/about/staff-update",
+        "/government/organisations/department-for-business-innovation-skills/about/staff-update",
+        "/government/organisations/department-for-communities-and-local-government/about/staff-update",
+        "/government/organisations/department-for-environment-food-rural-affairs/about/staff-update",
+        "/government/organisations/department-for-transport/about/staff-update",
+        "/government/organisations/department-for-work-pensions/about/staff-update",
+        "/government/organisations/driving-standards-agency/about/staff-update",
+        "/government/organisations/environment-agency/about/staff-update",
+        "/government/organisations/government-actuarys-department/about/staff-update"
+      ]
+    },
+    {
+      "name": "media_enquiries",
+      "count": 51,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/cabinet-office/about/media-enquiries",
+        "/government/organisations/charity-commission/about/media-enquiries",
+        "/government/organisations/companies-house/about/media-enquiries",
+        "/government/organisations/companies-house/about/media-enquiries.cy",
+        "/government/organisations/defence-electronics-and-components-agency/about/media-enquiries",
+        "/government/organisations/department-for-business-energy-and-industrial-strategy/about/media-enquiries",
+        "/government/organisations/department-for-business-innovation-skills/about/media-enquiries",
+        "/government/organisations/department-for-education/about/media-enquiries",
+        "/government/organisations/department-for-environment-food-rural-affairs/about/media-enquiries",
+        "/government/organisations/department-for-international-development/about/media-enquiries"
+      ]
+    },
+    {
+      "name": "procurement",
+      "count": 71,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/cabinet-office/about/procurement",
+        "/government/organisations/centre-for-environment-fisheries-and-aquaculture-science/about/procurement",
+        "/government/organisations/civil-nuclear-constabulary/about/procurement",
+        "/government/organisations/companies-house/about/procurement",
+        "/government/organisations/companies-house/about/procurement.cy",
+        "/government/organisations/competition-and-markets-authority/about/procurement",
+        "/government/organisations/defence-electronics-and-components-agency/about/procurement",
+        "/government/organisations/defence-infrastructure-organisation/about/procurement",
+        "/government/organisations/defence-science-and-technology-laboratory/about/procurement",
+        "/government/organisations/department-for-business-innovation-skills/about/procurement"
+      ]
+    },
+    {
+      "name": "petitions_and_campaigns",
+      "count": 2,
+      "schema_names": [
+        "placeholder_corporate_information_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/organisations/department-for-communities-and-local-government/about/petitions-and-campaigns",
+        "/government/organisations/department-for-international-development/about/petitions-and-campaigns"
+      ]
+    },
+    {
+      "name": "contact",
+      "count": 131,
+      "schema_names": [
+        "contact"
+      ],
+      "publishing_apps": [
+        "contacts"
+      ],
+      "rendering_apps": [
+        "contacts-frontend"
+      ],
+      "examples": [
+        "/government/organisations/hm-revenue-customs/contact/agent-dedicated-line-debt-management",
+        "/government/organisations/hm-revenue-customs/contact/agent-dedicated-line-self-assessment-or-paye-for-individuals",
+        "/government/organisations/hm-revenue-customs/contact/aggregates-levy",
+        "/government/organisations/hm-revenue-customs/contact/air-passenger-duty",
+        "/government/organisations/hm-revenue-customs/contact/alcohol-and-tobacco-warehousing-declaration-atwd-online-services-helpdesk",
+        "/government/organisations/hm-revenue-customs/contact/alcohol-duties",
+        "/government/organisations/hm-revenue-customs/contact/alcohol-duties-national-registration-unit",
+        "/government/organisations/hm-revenue-customs/contact/annual-tax-on-enveloped-dwellings-ated",
+        "/government/organisations/hm-revenue-customs/contact/automatic-exchange-of-information-financial-institutions",
+        "/government/organisations/hm-revenue-customs/contact/bereavement-and-deceased-estate"
+      ]
+    },
+    {
+      "name": "placeholder_person",
+      "count": 2219,
+      "schema_names": [
+        "placeholder_person"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/people/2224",
+        "/government/people/adam-kettle-williams",
+        "/government/people/adam-sambrook",
+        "/government/people/adam-sewell-jones",
+        "/government/people/adam-singer",
+        "/government/people/adam-thomson-cmg",
+        "/government/people/adam-thomson-cmg.ur",
+        "/government/people/adrian-davis",
+        "/government/people/adrian-jackson",
+        "/government/people/adrian-joseph"
+      ]
+    },
+    {
+      "name": "person",
+      "count": 582,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/people/adele-downey",
+        "/government/people/adrian-johns",
+        "/government/people/adrian-long",
+        "/government/people/adrian-masters",
+        "/government/people/alan-duncan",
+        "/government/people/alan-massey",
+        "/government/people/alan-milburn",
+        "/government/people/alastair-morgan",
+        "/government/people/alastair-morgan.zh",
+        "/government/people/alec-pybus"
+      ]
+    },
+    {
+      "name": "policy",
+      "count": 219,
+      "schema_names": [
+        "policy"
+      ],
+      "publishing_apps": [
+        "policy-publisher"
+      ],
+      "rendering_apps": [
+        "finder-frontend"
+      ],
+      "examples": [
+        "/government/policies/2012-olympic-and-paralympic-legacy",
+        "/government/policies/academies-and-free-schools",
+        "/government/policies/access-to-financial-services",
+        "/government/policies/access-to-higher-education",
+        "/government/policies/access-to-the-countryside",
+        "/government/policies/accessible-transport",
+        "/government/policies/administrative-justice-reform",
+        "/government/policies/afghanistan",
+        "/government/policies/alcohol-sales",
+        "/government/policies/animal-and-plant-health"
+      ]
+    },
+    {
+      "name": "placeholder_policy",
+      "count": 1,
+      "schema_names": [
+        "placeholder_policy"
+      ],
+      "publishing_apps": [
+        "policy-publisher"
+      ],
+      "rendering_apps": [
+        "finder-frontend"
+      ],
+      "examples": [
+        "/government/policies/schools-and-college-qualifications-and-curriculum"
+      ]
+    },
+    {
+      "name": "guidance",
+      "count": 21064,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/0-to-5-public-health-services-transfer-of-commissioning",
+        "/government/publications/01-user-guide-for-contract-pricing-statement",
+        "/government/publications/02-user-guide-for-contract-notification-report",
+        "/government/publications/03-user-guide-for-contract-reporting-plan",
+        "/government/publications/04-user-guide-for-quarterly-contract-report",
+        "/government/publications/05-user-guide-for-interim-contract-report-higher-value-50-million-or-more",
+        "/government/publications/06-user-guide-for-interim-contract-report-lower-value-under-50-million",
+        "/government/publications/07-user-guide-for-contract-completion-report",
+        "/government/publications/08-user-guide-for-contract-costs-statement",
+        "/government/publications/09-user-guide-for-on-demand-contract-report"
+      ]
+    },
+    {
+      "name": "foi_release",
+      "count": 8796,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/10-downing-street-flat-refurbishment",
+        "/government/publications/10-most-visited-websites",
+        "/government/publications/10-year-long-residency-applications-received-from-january-2012-to-december-2013",
+        "/government/publications/10-years-long-residence-set-o-applications-march-and-april-2013",
+        "/government/publications/12-1402-secondments-to-decc",
+        "/government/publications/12-1493-centre-for-sustainable-energy-contract",
+        "/government/publications/12-1517-request-for-copies-of-3-oil-pollutions-emergency-plans",
+        "/government/publications/12-1550-levy-control-framework-spending-estimates",
+        "/government/publications/12-1554-contact-between-hitachi-ltd-and-decc-regarding-the-sale-of-horizon-nuclear-power",
+        "/government/publications/12-1584-secondments-into-decc"
+      ]
+    },
+    {
+      "name": "decision",
+      "count": 3675,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/10-fraudulent-charities-case-report",
+        "/government/publications/a1-dishforth-to-barton-improvement-scheme-decision-letter",
+        "/government/publications/a1-scotch-corner-to-barton-scheme-decision-letter",
+        "/government/publications/a15-lincoln-eastern-bypass-decision-letter",
+        "/government/publications/a21-tonbridge-to-pembury-dualling-scheme-decision-letter",
+        "/government/publications/a45-and-a46-tollbar-end-improvement-decision-letter",
+        "/government/publications/a45-and-a46-tollbar-end-junction-improvement-decision-letter",
+        "/government/publications/a45-coventry-road-bridge-widening-decision-letter",
+        "/government/publications/a46-newark-to-widmerpool-improvement-decision-letter",
+        "/government/publications/a465-hereford-link-road-decision-letter"
+      ]
+    },
+    {
+      "name": "policy_paper",
+      "count": 7614,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/10-point-plan-for-eu-smart-regulation",
+        "/government/publications/150m-additional-support-funding-for-social-care-and-20m-additional-disabled-facilities-grant-funding",
+        "/government/publications/16-24-education-training-and-work-strategy-and-reforms",
+        "/government/publications/16-24-education-training-and-work-summary-of-strategy-and-reforms",
+        "/government/publications/16-to-18-core-maths-qualifications",
+        "/government/publications/16-to-19-funding-formula-review-funding-full-participation-and-study-programmes-for-young-people",
+        "/government/publications/2003-04-to-2010-11-programme-budgeting-data",
+        "/government/publications/2010-11-reference-costs-publication",
+        "/government/publications/2010-11-working-age-adult-and-older-adult-national-survey-of-investment-in-mental-health-services",
+        "/government/publications/2010-annual-report-on-the-implementation-of-council-regulation-ec-no-1185-2003-shark-finning"
+      ]
+    },
+    {
+      "name": "promotional",
+      "count": 881,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/101-police-non-emergency-number-resources",
+        "/government/publications/2011-iom-conference-feedback-form",
+        "/government/publications/2012-national-iom-conference",
+        "/government/publications/2016-national-curriculum-tests-for-key-stages-1-and-2-information-for-parents",
+        "/government/publications/2050-energy-and-emissions-pathway-conference-breakout-session-1-why-the-uk-built-its-2050-model",
+        "/government/publications/2050-pathways-calculator-how-to-use-the-calculator-and-develop-your-own",
+        "/government/publications/a-brief-history-of-dartmoor",
+        "/government/publications/a-guide-to-immunisations-for-babies-up-to-13-months-of-age",
+        "/government/publications/a-history-of-our-reserves",
+        "/government/publications/a-quick-guide-to-childhood-immunisation-for-the-parents-of-premature-babies"
+      ]
+    },
+    {
+      "name": "corporate_report",
+      "count": 8547,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/11-million-annual-report-and-accounts-2006-to-2007",
+        "/government/publications/2011-annual-report-of-the-interception-of-communications-commissioner",
+        "/government/publications/2012-annual-report-of-the-interception-of-communications-commissioner",
+        "/government/publications/2013-people-survey-results-for-dcms",
+        "/government/publications/2014-people-survey-results-for-dcms",
+        "/government/publications/2015-16-business-plan-review",
+        "/government/publications/2015-people-survey-results-for-dcms",
+        "/government/publications/2015-to-2016-business-plan",
+        "/government/publications/2020-export-drive",
+        "/government/publications/64th-annual-meeting-of-the-international-whaling-commision-uk-commissioners-report"
+      ]
+    },
+    {
+      "name": "impact_assessment",
+      "count": 780,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/14-to-16-qualifications-and-performance-tables-and-the-reform-of-equivalences",
+        "/government/publications/2012-diamond-jubilee-extra-bank-holiday-impact-assessment",
+        "/government/publications/24-advanced-learning-loans-regulatory-impact-assessment-annex-2-table",
+        "/government/publications/6-severn-tidal-power-impact-assessment",
+        "/government/publications/a-fairer-future-for-social-housing-impact-assessment",
+        "/government/publications/a-level-subject-content-equality-impact-assessment",
+        "/government/publications/a-statutory-registry-of-lobbyists-impact-assessment",
+        "/government/publications/abolishing-home-information-packs-impact-assessment",
+        "/government/publications/abolishing-the-infrastructure-planning-commission-impact-assessment",
+        "/government/publications/abolishing-the-regional-planning-tier-and-introducing-the-duty-to-cooperate-impact-assessment"
+      ]
+    },
+    {
+      "name": "notice",
+      "count": 7039,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/16-july-2015-firm-reference-numbers-for-traders",
+        "/government/publications/18-august-quantities-available-for-egg-import-quotas",
+        "/government/publications/18-august-quantities-available-for-pigmeat-import-quotas",
+        "/government/publications/18-august-quantities-available-for-poultrymeat-import-quotas",
+        "/government/publications/24-november-quantities-available-for-egg-import-quotas",
+        "/government/publications/24-november-quantities-available-for-pigmeat-import-quotas",
+        "/government/publications/24-november-quantities-available-for-poultrymeat-import-quotas",
+        "/government/publications/a-e-wrout-and-son-application-made-to-abstract-take-water",
+        "/government/publications/a-edgley-limited-application-made-to-abstract-water",
+        "/government/publications/a-r-wilson-limited-application-made-to-abstract-water"
+      ]
+    },
+    {
+      "name": "form",
+      "count": 4492,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/16-prosperity-fund-korea-programme_2nd-round-full-bidding-form",
+        "/government/publications/16-to-19-demographic-growth-capital-fund-forms",
+        "/government/publications/180-to-206-weeks-ultrasound-scan-tear-off-pad",
+        "/government/publications/2011-psychotropics-annual-return-form",
+        "/government/publications/2013-2014-bilateral-programme-fund",
+        "/government/publications/201415-prosperity-fund-korea-programme-project-concept-form",
+        "/government/publications/201516-prosperity-fund-korea-programme-full-bidding-form",
+        "/government/publications/201516-prosperity-fund-korea-programme-project-concept-form",
+        "/government/publications/201516-prosperity-fund-korea-programme_2nd-round-project-concept-form",
+        "/government/publications/24-advanced-learning-loans-facility-adjustment-request-form"
+      ]
+    },
+    {
+      "name": "transparency",
+      "count": 6957,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/16-to-19-allocation-data-2013-to-2014-academic-year",
+        "/government/publications/16-to-19-allocation-data-2014-to-2015-academic-year",
+        "/government/publications/16-to-19-allocation-data-2015-to-2016-academic-year",
+        "/government/publications/16-to-19-demographic-growth-capital-fund-allocation-data",
+        "/government/publications/16-to-19-sub-contracted-students-for-the-2014-to-2015-academic-year",
+        "/government/publications/20-september-2010-types-of-ukaid-funding-by-sector",
+        "/government/publications/201213-department-for-education-and-executive-agency-spend-over-25000",
+        "/government/publications/2016-uk-climate-finance-results",
+        "/government/publications/24-advanced-learning-loans-equality-impact-assessment-underlying-data",
+        "/government/publications/24-advanced-learning-loans-regulatory-impact-assessment-underlying-data"
+      ]
+    },
+    {
+      "name": "correspondence",
+      "count": 3689,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/16-to-19-allocations-efa-letter-to-aelp-april-2013",
+        "/government/publications/16-to-19-funding-18-year-old-mitigation",
+        "/government/publications/16-to-19-funding-funding-for-academic-year-2014-to-2015",
+        "/government/publications/16-to-19-funding-funding-for-academic-year-2015-to-2016",
+        "/government/publications/16-to-19-funding-funding-for-academic-year-2016-to-2017",
+        "/government/publications/162m-additional-winter-pressures-to-primary-care-trusts",
+        "/government/publications/2-dpmp-compounds",
+        "/government/publications/2010-11-funding-for-re-ablement-linked-to-hospital-discharge",
+        "/government/publications/2010-11-performance-related-pay-awards-for-staff-covered-by-the-pay-framework-for-very-senior-managers",
+        "/government/publications/2010-11-seasonal-influenza-prescription-of-antivirals-letter-from-the-cmo"
+      ]
+    },
+    {
+      "name": "international_treaty",
+      "count": 1008,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/1999-amendments-to-the-international-code-for-the-construction-and-equipment-of-ships-carrying-dangerous-chemicals-in-bulk",
+        "/government/publications/2003-amendments-to-the-protocol-of-1988-relating-to-the-international-convention-on-load-lines",
+        "/government/publications/2004-amendments-to-the-international-code-for-the-construction-and-equipment-of-ships-carrying-dangerous-chemicals-in-bulk",
+        "/government/publications/additional-protocol-to-the-convention-on-the-transfer-of-sentenced-persons",
+        "/government/publications/additional-protocol-to-the-convention-on-the-transfer-of-sentenced-persons--2",
+        "/government/publications/administrative-agreement-concerning-the-arbitral-tribunal-and-the-mixed-commission-under-the-agreement-on-german-external-debts-signed-at-london-on-th",
+        "/government/publications/agreement-amending-the-administrative-agreement-of-december-1-1954-concerning-the-arbitral-tribunal-and-mixed-commission-under-the-agreement-on-germa",
+        "/government/publications/agreement-amending-the-administrative-agreement-of-december-1-1954-concerning-the-arbitral-tribunal-and-the-mixed-commission-under-the-agreement-of-f",
+        "/government/publications/agreement-amending-the-administrative-agreement-signed-at-bonn-on-december-1-1954-concerning-the-arbitral-tribunal-and-the-mixed-commission-under-th",
+        "/government/publications/agreement-amending-the-partnership-agreement-between-the-african-caribbean-and-pacific-group-of-states-and-the-ec"
+      ]
+    },
+    {
+      "name": "independent_report",
+      "count": 2103,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/2013-belgo-british-conference-report-on-history-and-reconciliation",
+        "/government/publications/2014-belgo-british-conference-report-on-entrepreneurial-universities-in-the-development-and-transfer-of-high-tech-innovation-systems",
+        "/government/publications/37th-annual-report-on-senior-salaries-2015",
+        "/government/publications/a-child-centred-system-the-governments-response-to-the-munro-review-of-child-protection",
+        "/government/publications/a-complaint-about-the-electoral-commission",
+        "/government/publications/a-fresh-start-for-the-strategic-road-network",
+        "/government/publications/a-house-for-the-future-royal-commission-on-the-reform-of-the-house-of-lords",
+        "/government/publications/a-local-inquiry-into-the-public-library-service-provided-by-wirral-metropolitan-borough-council",
+        "/government/publications/a-mission-oriented-approach-to-building-the-entrepreneurial-state",
+        "/government/publications/a-new-vision-for-older-workers-retain-retrain-recruit"
+      ]
+    },
+    {
+      "name": "statutory_guidance",
+      "count": 880,
+      "schema_names": [
+        "publication",
+        "placeholder_publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/2016-assessment-and-reporting-arrangements-pdf-format-versions",
+        "/government/publications/2017-interim-frameworks-for-teacher-assessment-at-the-end-of-key-stage-1",
+        "/government/publications/2017-interim-frameworks-for-teacher-assessment-at-the-end-of-key-stage-2",
+        "/government/publications/2017-pre-key-stage-1-pupils-working-below-the-test-standard",
+        "/government/publications/2017-pre-key-stage-2-pupils-working-below-the-test-standard",
+        "/government/publications/abstraction-charges-scheme-april-2014-to-march-2015",
+        "/government/publications/access-to-and-use-of-buildings-approved-document-m",
+        "/government/publications/access-to-work-dwp-provider-guidance",
+        "/government/publications/adoption-statutory-guidance-2013",
+        "/government/publications/adult-autism-strategy-statutory-guidance"
+      ]
+    },
+    {
+      "name": "map",
+      "count": 848,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/abertawe-swansea-inspire-index-polygon-data",
+        "/government/publications/additional-provision-2-july-2015-plans-and-sections",
+        "/government/publications/additional-provision-3-september-2015-plans-and-sections",
+        "/government/publications/additional-provision-4-october-2015-plans-and-sections",
+        "/government/publications/additional-provision-5-december-2015-plans-and-sections",
+        "/government/publications/additional-provision-september-2014-plans-and-sections",
+        "/government/publications/adur-inspire-index-polygon-data--2",
+        "/government/publications/ainsdale-sand-dunes-nnr-public-access-for-horse-riding-and-cycling",
+        "/government/publications/allerdale-inspire-index-polygon-data--2",
+        "/government/publications/amber-valley-inspire-index-polygon-data"
+      ]
+    },
+    {
+      "name": "regulation",
+      "count": 723,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/publications/accreditation-criterion",
+        "/government/publications/additional-certificate-requirements",
+        "/government/publications/aircraft-post-crash-management-apcm-aide-memoire",
+        "/government/publications/controlled-assessment-regulations-for-functional-skills",
+        "/government/publications/criteria-for-adult-literacy-and-numeracy-qualifications",
+        "/government/publications/criteria-for-advanced-extension-awards-aeas",
+        "/government/publications/criteria-for-determining-whether-a-qualification-is-relevant-for-the-purposes-of-the-education-and-skills-act-2008",
+        "/government/publications/criteria-for-english-for-speakers-of-other-languages-esol-qualifications",
+        "/government/publications/criteria-for-entry-level-qualifications",
+        "/government/publications/criteria-for-foundation-higher-and-advanced-diploma-qualifications"
+      ]
+    },
+    {
+      "name": "speech",
+      "count": 5646,
+      "schema_names": [
+        "placeholder_speech"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/speeches/10-million-new-births-registered-means-an-additional-10-million-children-relying-on-unicef-unicef-cannot-and-must-not-lose-momentum",
+        "/government/speeches/10-million-sainsbury-s-investment-to-inspire-a-new-sporting-generation",
+        "/government/speeches/10th-anniversary-of-istanbul-bombing",
+        "/government/speeches/11-september-2012-norman-lamb-king-s-fund-integration",
+        "/government/speeches/14-november-2012-jeremy-hunt-age-uk",
+        "/government/speeches/14th-anniversary-of-the-centre-for-european-reform",
+        "/government/speeches/150th-anniversary-of-arthur-wharton",
+        "/government/speeches/16-january-2013-jeremy-hunt-policy-exchange-from-notepad-to-ipad-technology-and-the-nhs",
+        "/government/speeches/16th-anniversary-of-the-genocide-at-srebrenica",
+        "/government/speeches/17-may-2012-paul-burstow-community-care-live"
+      ]
+    },
+    {
+      "name": "authored_article",
+      "count": 236,
+      "schema_names": [
+        "placeholder_speech"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/speeches/100-days-article-by-david-cameron",
+        "/government/speeches/a-commitment-to-care",
+        "/government/speeches/a-definition-of-antisemitism",
+        "/government/speeches/a-digital-nhs-for-everyone",
+        "/government/speeches/a-positive-case-for-britains-future-in-a-reformed-eu",
+        "/government/speeches/a-strong-nhs-needs-a-strong-economy",
+        "/government/speeches/accelerated-access-review-extended-to-april-2016",
+        "/government/speeches/affordable-housing-off-site-construction-and-estates-regeneration",
+        "/government/speeches/all-the-talents-policy-needs-social-science-and-humanities-input",
+        "/government/speeches/ambassadors-for-evidence"
+      ]
+    },
+    {
+      "name": "written_statement",
+      "count": 1721,
+      "schema_names": [
+        "placeholder_speech"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/speeches/15-million-growth-funding-on-sustainable-transport",
+        "/government/speeches/2010-11-departmental-expenditure-limit",
+        "/government/speeches/2012-annual-human-rights-and-democracy-report",
+        "/government/speeches/2012-olympic-and-paralympic-games-public-consultation-on-the-use-of-wanstead-flats",
+        "/government/speeches/2014-winter-olympics-security",
+        "/government/speeches/266-million-investment-in-local-sustainable-transport-schemes",
+        "/government/speeches/28th-offshore-round-of-oil-and-gas-licensing",
+        "/government/speeches/a-bill-of-rights-for-northern-ireland-next-steps",
+        "/government/speeches/a-christian-ethos-strengthens-our-nation",
+        "/government/speeches/a-review-of-coalfields-regeneration-government-response"
+      ]
+    },
+    {
+      "name": "oral_statement",
+      "count": 458,
+      "schema_names": [
+        "placeholder_speech"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/speeches/2011-02-14-quarterly-statement-on-afghanistan",
+        "/government/speeches/2011-09-08-statement-on-the-report-into-the-death-of-mr-baha-mousa-in-iraq-in-2003",
+        "/government/speeches/2011-10-18-quarterly-statement-on-afghanistan--2",
+        "/government/speeches/2012-04-26-afghanistan-statement",
+        "/government/speeches/2012-05-14-address-to-the-3rd-annual-electrical-infrastructure-security-summit",
+        "/government/speeches/2012-oecd-pisa-results",
+        "/government/speeches/2012-olympic-games-opportunity-for-maritime-industries",
+        "/government/speeches/a-new-era-for-universities",
+        "/government/speeches/a-renaissance-in-modern-manufacturing",
+        "/government/speeches/abu-qatada-court-ruling-oral-statement-by-the-home-secretary"
+      ]
+    },
+    {
+      "name": "statistical_data_set",
+      "count": 565,
+      "schema_names": [
+        "placeholder_statistical_data_set"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/statistical-data-sets/2011-skills-for-life-survey-small-area-estimation-data",
+        "/government/statistical-data-sets/2012-based-household-projections-detailed-data-for-modelling-and-analytical-purposes",
+        "/government/statistical-data-sets/2014-based-household-projections-detailed-data-for-modelling-and-analytical-purposes",
+        "/government/statistical-data-sets/abortion-statistics-england-and-wales-2011",
+        "/government/statistical-data-sets/abortion-statistics-england-and-wales-2013",
+        "/government/statistical-data-sets/abortion-statistics-england-and-wales-2014",
+        "/government/statistical-data-sets/abortion-statistics-england-and-wales-2015",
+        "/government/statistical-data-sets/acs01-availability-of-transport-to-key-services-or-work-among-households",
+        "/government/statistical-data-sets/acs02-availability-of-transport-to-key-services-or-work-among-users",
+        "/government/statistical-data-sets/acs03-number-of-employment-and-key-service-sites-available"
+      ]
+    },
+    {
+      "name": "official_statistics",
+      "count": 6293,
+      "schema_names": [
+        "publication",
+        "placeholder_publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/statistics/2001-rural-urban-definition-la-classification-and-other-geographies",
+        "/government/statistics/2004-06-sport-satellite-account-report",
+        "/government/statistics/2008-2010-sport-satellite-accounts-for-the-uk",
+        "/government/statistics/2010-british-social-attitudes-survey-attitudes-to-transport",
+        "/government/statistics/2011-1-phenyl-2-propanone-bmk-annual-return",
+        "/government/statistics/2011-2012-sport-satellite-account-for-the-uk",
+        "/government/statistics/2011-based-interim-household-projections-quality-report",
+        "/government/statistics/2011-census-analysis-changes-in-the-older-care-home-resident-population-at-local-authority-level-2001-to-2011",
+        "/government/statistics/2011-census-analysis-general-health-in-overcrowded-and-under-occupied-households-in-england-and-wales-2011",
+        "/government/statistics/2011-census-results-for-rural-england"
+      ]
+    },
+    {
+      "name": "national_statistics",
+      "count": 5036,
+      "schema_names": [
+        "placeholder_publication",
+        "publication"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/statistics/2011-census-3i",
+        "/government/statistics/2011-census-additional-detailed-and-local-characteristics-tables-for-england-and-wales",
+        "/government/statistics/2011-census-additional-detailed-and-local-characteristics-tables-for-england-and-wales-part-2",
+        "/government/statistics/2011-census-analysis-coastal-communities",
+        "/government/statistics/2011-census-analysis-do-demographic-and-socio-economic-characteristics-of-those-living-alone-in-england-and-wales-differ-from-the-general-population",
+        "/government/statistics/2011-census-analysis-social-and-economic-characteristics-by-length-of-residence-of-migrant-populations-in-england-and-wales",
+        "/government/statistics/2011-census-analysis-what-does-the-2011-census-tell-us-about-people-living-in-communal-establishments",
+        "/government/statistics/2011-census-analysis-what-does-the-2011-census-tell-us-about-work-related-second-addresses-in-england-and-wales",
+        "/government/statistics/2011-census-analysis-workers-aged-65-and-over-in-the-2011-census",
+        "/government/statistics/2011-census-detailed-uk-migration-statistics"
+      ]
+    },
+    {
+      "name": "statistics_announcement",
+      "count": 3540,
+      "schema_names": [
+        "statistics_announcement"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "government-frontend"
+      ],
+      "examples": [
+        "/government/statistics/announcements/2008-2010-sport-satellite-accounts-for-the-uk",
+        "/government/statistics/announcements/2011-2012-sport-satellite-account-for-the-uk",
+        "/government/statistics/announcements/2011-census-out-of-term-population-statistics-for-output-areas-in-england-and-wales",
+        "/government/statistics/announcements/2012-statutory-child-maintenance-scheme-aug-2013-to-aug-2015-experimental",
+        "/government/statistics/announcements/2013-to-2014-capital-expenditure-and-financing-for-housing-revenue-account",
+        "/government/statistics/announcements/2014-15-supplementary-data-housing-revenue-account-capital-expenditure-financing-and-major-repairs-reserve",
+        "/government/statistics/announcements/2014-national-curriculum-tests-review-outcomes-provisional",
+        "/government/statistics/announcements/2015-primary-school-performance-tables",
+        "/government/statistics/announcements/24-advanced-learning-loans-application-information-july-2015",
+        "/government/statistics/announcements/24-advanced-learning-loans-application-information-june-2015"
+      ]
+    },
+    {
+      "name": "official",
+      "count": 937,
+      "schema_names": [
+        "statistics_announcement"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "government-frontend"
+      ],
+      "examples": [
+        "/government/statistics/announcements/2012-statutory-child-maintenance-scheme-aug-2013-to-aug-2016-experimental",
+        "/government/statistics/announcements/2017-child-health-profiles",
+        "/government/statistics/announcements/2017-health-profiles",
+        "/government/statistics/announcements/24-advanced-learning-loans-application-information-august-2015-to-july-2016-end-of-year-report",
+        "/government/statistics/announcements/a-note-on-childbearing-by-socio-economic-status-and-country-of-birth-of-mother",
+        "/government/statistics/announcements/access-to-work-individuals-helped-to-end-of-march-2016",
+        "/government/statistics/announcements/accident-and-emergency-attendances-in-england-2015-16",
+        "/government/statistics/announcements/accredited-programmes-bulletin-2015-to-2016",
+        "/government/statistics/announcements/active-tse-surveillance-in-great-britain-and-northern-ireland--10",
+        "/government/statistics/announcements/active-tse-surveillance-in-great-britain-and-northern-ireland--11"
+      ]
+    },
+    {
+      "name": "national",
+      "count": 1132,
+      "schema_names": [
+        "statistics_announcement"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "government-frontend"
+      ],
+      "examples": [
+        "/government/statistics/announcements/2016-key-stage-2-national-curriculum-tests-review-outcomes-provisional",
+        "/government/statistics/announcements/2016-mid-year-population-estimates-for-northern-ireland",
+        "/government/statistics/announcements/2016-primary-school-performance-tables",
+        "/government/statistics/announcements/2017-key-stage-2-national-curriculum-tests-review-outcomes-provisional",
+        "/government/statistics/announcements/2017-primary-school-performance-tables",
+        "/government/statistics/announcements/a-level-and-other-16-18-results-2015-to-2016",
+        "/government/statistics/announcements/a-level-and-other-16-18-results-2016-to-2017",
+        "/government/statistics/announcements/abortion-statistics-england-and-wales-2015",
+        "/government/statistics/announcements/accident-and-emergency-survey-survey-2016",
+        "/government/statistics/announcements/admission-appeals-for-maintained-primary-and-secondary-schools-in-england-2015-to-2016"
+      ]
+    },
+    {
+      "name": "placeholder_topical_event",
+      "count": 41,
+      "schema_names": [
+        "placeholder_topical_event"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/topical-events/2014-overseas-territories-joint-ministerial-council",
+        "/government/topical-events/anti-corruption-summit-london-2016",
+        "/government/topical-events/autumn-statement-2012",
+        "/government/topical-events/autumn-statement-2013",
+        "/government/topical-events/autumn-statement-2014",
+        "/government/topical-events/autumn-statement-and-spending-review-2015",
+        "/government/topical-events/bastion-memorial-dedication",
+        "/government/topical-events/battle-of-the-somme-centenary-commemorations",
+        "/government/topical-events/budget-2013",
+        "/government/topical-events/budget-2014"
+      ]
+    },
+    {
+      "name": "topical_event_about_page",
+      "count": 25,
+      "schema_names": [
+        "topical_event_about_page"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "government-frontend"
+      ],
+      "examples": [
+        "/government/topical-events/2014-overseas-territories-joint-ministerial-council/about",
+        "/government/topical-events/anti-corruption-summit-london-2016/about",
+        "/government/topical-events/autumn-statement-2013/about",
+        "/government/topical-events/battle-of-the-somme-centenary-commemorations/about",
+        "/government/topical-events/d5-london-2014-leading-digital-governments/about",
+        "/government/topical-events/daesh/about",
+        "/government/topical-events/ebola-virus-government-response/about",
+        "/government/topical-events/eu-referendum/about",
+        "/government/topical-events/farming/about",
+        "/government/topical-events/girl-summit-2014/about"
+      ]
+    },
+    {
+      "name": "topical_event",
+      "count": 17,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/topical-events/autumn-statement-2016",
+        "/government/topical-events/daesh",
+        "/government/topical-events/eu-referendum",
+        "/government/topical-events/farming",
+        "/government/topical-events/national-apprenticeship-awards-2016",
+        "/government/topical-events/national-apprenticeship-week-2016",
+        "/government/topical-events/national-apprenticeship-week-2017",
+        "/government/topical-events/queens-speech-2013",
+        "/government/topical-events/queens-speech-2014",
+        "/government/topical-events/queens-speech-2015"
+      ]
+    },
+    {
+      "name": "placeholder_policy_area",
+      "count": 45,
+      "schema_names": [
+        "placeholder_policy_area"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/topics/arts-and-culture",
+        "/government/topics/borders-and-immigration",
+        "/government/topics/business-and-enterprise",
+        "/government/topics/children-and-young-people",
+        "/government/topics/climate-change",
+        "/government/topics/community-and-society",
+        "/government/topics/consumer-rights-and-issues",
+        "/government/topics/crime-and-policing",
+        "/government/topics/defence-and-armed-forces",
+        "/government/topics/employment"
+      ]
+    },
+    {
+      "name": "policy_area",
+      "count": 2,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/topics/europe",
+        "/government/topics/pensions-and-ageing-society"
+      ]
+    },
+    {
+      "name": "news_article",
+      "count": 14118,
+      "schema_names": [
+        "placeholder_world_location_news_article"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/world-location-news/%D0%BC%D0%B8%D0%BD%D0%B8%D1%81%D1%82%D1%80-%D0%B2%D0%B8%D0%BD%D1%81-%D0%BA%D0%B5%D0%B9%D0%B1%D0%BB-%D0%BF%D1%80%D0%B8%D0%B1%D1%8B%D0%BB-%D0%B2-%D1%80%D0%BE%D1%81%D1%81%D0%B8%D1%8E-%D1%81-%D0%BE%D1%84%D0%B8%D1%86%D0%B8%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%BC-%D0%B2%D0%B8%D0%B7%D0%B8%D1%82%D0%BE%D0%BC",
+        "/government/world-location-news/%D0%BC%D0%B8%D0%BD%D0%B8%D1%81%D1%82%D1%80-%D0%B2%D0%B8%D0%BD%D1%81-%D0%BA%D0%B5%D0%B9%D0%B1%D0%BB-%D0%BF%D1%80%D0%B8%D0%B1%D1%8B%D0%BB-%D0%B2-%D1%80%D0%BE%D1%81%D1%81%D0%B8%D1%8E-%D1%81-%D0%BE%D1%84%D0%B8%D1%86%D0%B8%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%BC-%D0%B2%D0%B8%D0%B7%D0%B8%D1%82%D0%BE%D0%BC.ru",
+        "/government/world-location-news/%D1%83%D0%BA%D1%80%D0%B5%D0%BF%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5-%D1%81%D0%B2%D0%BE%D0%B1%D0%BE%D0%B4%D1%8B-%D0%B2%D0%B5%D1%80%D0%BE%D0%B8%D1%81%D0%BF%D0%BE%D0%B2%D0%B5%D0%B4%D0%B0%D0%BD%D0%B8%D1%8F-%D0%B2-%D1%80%D0%B5%D1%81%D0%BF%D1%83%D0%B1%D0%BB%D0%B8%D0%BA%D0%B5-%D0%BA%D0%B0%D0%B7%D0%B0%D1%85%D1%81%D1%82%D0%B0%D0%BD",
+        "/government/world-location-news/%D7%91%D7%A8%D7%9B%D7%AA-%D7%A8%D7%90%D7%A9-%D7%9E%D7%9E%D7%A9%D7%9C%D7%AA-%D7%91%D7%A8%D7%99%D7%98%D7%A0%D7%99%D7%94-%D7%9C%D7%A9%D7%A0%D7%94-%D7%94%D7%97%D7%93%D7%A9%D7%94",
+        "/government/world-location-news/%D8%A3%D9%83%D8%A8%D8%B1-%D8%A7%D8%B3%D8%AA%D8%AC%D8%A7%D8%A8%D8%A9-%D8%A8%D8%B1%D9%8A%D8%B7%D8%A7%D9%86%D9%8A%D8%A9-%D8%B9%D9%84%D9%89-%D8%A7%D9%84%D8%A5%D8%B7%D9%84%D8%A7%D9%82-%D9%84%D9%84%D8%A3%D8%B2%D9%85%D8%A9-%D8%A7%D9%84%D8%B3%D9%88%D8%B1%D9%8A%D8%A9",
+        "/government/world-location-news/%D9%81%D8%B1%D9%8A%D9%82-%D8%A7%D9%84%D8%A7%D8%B3%D8%AA%D8%B9%D8%B1%D8%A7%D8%B6%D8%A7%D8%AA-%D8%A7%D9%84%D8%AC%D9%88%D9%8A%D8%A9-%D8%A7%D9%84%D8%A8%D8%B1%D9%8A%D8%B7%D8%A7%D9%86%D9%8A%D8%A9-%D8%B1%D9%8A%D8%AF-%D8%A3%D8%B1%D9%88%D8%B2-%D9%8A%D8%B2%D9%88%D8%B1-%D8%A7%D9%84%D8%A3%D8%B1%D8%AF%D9%86",
+        "/government/world-location-news/%D9%88%D8%B2%D9%8A%D8%B1-%D8%A7%D9%84%D8%AF%D9%88%D9%84%D8%A9-%D9%84%D8%B4%D8%A4%D9%88%D9%86-%D9%88%D9%8A%D9%84%D8%B2-%D9%8A%D8%B2%D9%88%D8%B1-%D8%A7%D9%84%D8%B3%D9%84%D8%B7%D9%86%D8%A9-%D8%A7%D9%84%D9%8A%D9%88%D9%85",
+        "/government/world-location-news/%D9%88%D9%81%D8%AF-%D8%AA%D8%AC%D8%A7%D8%B1%D9%8A-%D8%A8%D8%B1%D9%8A%D8%B7%D8%A7%D9%86%D9%8A-%D8%A8%D8%A7%D9%84%D9%82%D8%A7%D9%87%D8%B1%D8%A9-%D9%84%D8%AF%D8%B1%D8%A7%D8%B3%D8%A9-%D8%A7%D9%84%D8%AA%D8%B9%D8%A7%D9%88%D9%86-%D9%81%D9%8A-%D9%85%D8%B4%D8%B1%D9%88%D8%B9-%D9%82%D9%86%D8%A7%D8%A9-%D8%A7%D9%84%D8%B3%D9%88%D9%8A%D8%B3",
+        "/government/world-location-news/%D9%88%D9%81%D8%AF-%D8%AA%D8%AC%D8%A7%D8%B1%D9%8A-%D8%A8%D8%B1%D9%8A%D8%B7%D8%A7%D9%86%D9%8A-%D8%A8%D8%A7%D9%84%D9%82%D8%A7%D9%87%D8%B1%D8%A9-%D9%84%D8%AF%D8%B1%D8%A7%D8%B3%D8%A9-%D8%A7%D9%84%D8%AA%D8%B9%D8%A7%D9%88%D9%86-%D9%81%D9%8A-%D9%85%D8%B4%D8%B1%D9%88%D8%B9-%D9%82%D9%86%D8%A7%D8%A9-%D8%A7%D9%84%D8%B3%D9%88%D9%8A%D8%B3.ar",
+        "/government/world-location-news/%E5%8A%A0%E5%BC%B7%E9%9B%99%E9%82%8A%E6%99%BA%E8%B2%A1%E6%AC%8A%E5%90%88%E4%BD%9C-%E8%8B%B1%E5%9C%8B%E8%88%87%E5%8F%B0%E7%81%A3%E7%B0%BD%E7%BD%B2%E6%99%BA%E6%85%A7%E8%B2%A1%E7%94%A2%E6%AC%8A%E5%90%88%E4%BD%9C%E5%82%99%E5%BF%98%E9%8C%84"
+      ]
+    },
+    {
+      "name": "placeholder_world_location",
+      "count": 258,
+      "schema_names": [
+        "placeholder_world_location"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/world/afghanistan",
+        "/government/world/afghanistan.dr",
+        "/government/world/albania",
+        "/government/world/albania.sq",
+        "/government/world/algeria",
+        "/government/world/algeria.ar",
+        "/government/world/american-samoa",
+        "/government/world/andorra",
+        "/government/world/anguilla",
+        "/government/world/antigua-and-barbuda"
+      ]
+    },
+    {
+      "name": "world_location",
+      "count": 62,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/world/angola",
+        "/government/world/angola.pt",
+        "/government/world/armenia",
+        "/government/world/armenia.hy",
+        "/government/world/austria",
+        "/government/world/austria.de",
+        "/government/world/barbados",
+        "/government/world/brunei",
+        "/government/world/burma",
+        "/government/world/cambodia"
+      ]
+    },
+    {
+      "name": "placeholder_worldwide_organisation",
+      "count": 377,
+      "schema_names": [
+        "placeholder_worldwide_organisation"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/world/organisations/british-antarctic-territory",
+        "/government/world/organisations/british-consulate-bali",
+        "/government/world/organisations/british-consulate-bordeaux",
+        "/government/world/organisations/british-consulate-brisbane",
+        "/government/world/organisations/british-consulate-general-alexandria",
+        "/government/world/organisations/british-consulate-general-atlanta",
+        "/government/world/organisations/british-consulate-general-auckland",
+        "/government/world/organisations/british-consulate-general-barcelona",
+        "/government/world/organisations/british-consulate-general-belo-horizonte",
+        "/government/world/organisations/british-consulate-general-boston"
+      ]
+    },
+    {
+      "name": "worldwide_organisation",
+      "count": 197,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/government/world/organisations/british-consulate-alicante",
+        "/government/world/organisations/british-consulate-general-amsterdam",
+        "/government/world/organisations/british-consulate-general-dusseldorf",
+        "/government/world/organisations/british-consulate-marseille",
+        "/government/world/organisations/british-consulate-sylhet",
+        "/government/world/organisations/british-deputy-high-commission-chandigarh",
+        "/government/world/organisations/british-deputy-high-commission-chandigarh.hi",
+        "/government/world/organisations/british-embassy-athens",
+        "/government/world/organisations/british-embassy-athens.el",
+        "/government/world/organisations/british-embassy-belgrade"
+      ]
+    },
+    {
+      "name": "detailed_guide",
+      "count": 4176,
+      "schema_names": [
+        "detailed_guide"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "government-frontend",
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/guidance/16-to-18-education-free-meals",
+        "/guidance/16-to-18-education-free-meals-for-academic-year-2016-to-2017",
+        "/guidance/16-to-18-residential-bursary-fund",
+        "/guidance/16-to-18-residential-bursary-fund-guide-2016-to-2017-academic-year",
+        "/guidance/16-to-18-residential-support-scheme",
+        "/guidance/16-to-18-residential-support-scheme-for-academic-year-2016-to-2017",
+        "/guidance/16-to-19-bursary-fund-guide-for-2015-to-2016",
+        "/guidance/16-to-19-bursary-fund-guide-for-2016-to-2017",
+        "/guidance/16-to-19-capital-funding",
+        "/guidance/16-to-19-education-accountability"
+      ]
+    },
+    {
+      "name": "manual",
+      "count": 23,
+      "schema_names": [
+        "manual"
+      ],
+      "publishing_apps": [
+        "manuals-publisher",
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "manuals-frontend"
+      ],
+      "examples": [
+        "/guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara",
+        "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara",
+        "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara",
+        "/guidance/buying-for-schools",
+        "/guidance/capital-funding-guide",
+        "/guidance/contact-the-government-digital-service",
+        "/guidance/content-design",
+        "/guidance/convert-to-an-academy-information-for-schools",
+        "/guidance/countryside-stewardship-manual",
+        "/guidance/digital-and-technology-skills"
+      ]
+    },
+    {
+      "name": "manual_section",
+      "count": 506,
+      "schema_names": [
+        "manual_section"
+      ],
+      "publishing_apps": [
+        "manuals-publisher",
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "manuals-frontend"
+      ],
+      "examples": [
+        "/guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-1-introduction",
+        "/guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-2-early-years-foundation-stage-profile",
+        "/guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-3-moderation",
+        "/guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-4-reporting-and-using-results",
+        "/guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-5-legal-requirements-and-responsibilities",
+        "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-1-introduction",
+        "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-10-keeping-and-maintaining-records",
+        "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-11-legal-requirements-and-responsibilities",
+        "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-2-key-changes",
+        "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-3-key-dates"
+      ]
+    },
+    {
+      "name": "detailed_guidance",
+      "count": 16,
+      "schema_names": [
+        "detailed_guide"
+      ],
+      "publishing_apps": [
+        "whitehall"
+      ],
+      "rendering_apps": [
+        "whitehall-frontend"
+      ],
+      "examples": [
+        "/guidance/apply-to-take-samples-analyse-sediment-and-make-minor-removals",
+        "/guidance/cattle-welfare-regulations",
+        "/guidance/data-verifying-services",
+        "/guidance/deer-health-welfare-and-movement",
+        "/guidance/defence-business-services-national-security-vetting",
+        "/guidance/disclosure-and-barring-service-criminal-record-checks-referrals-and-complaints",
+        "/guidance/energy-intensive-industries-compensation-for-carbon-leakage",
+        "/guidance/how-to-pay-and-invoice-for-digital-outcomes-and-specialists-services",
+        "/guidance/human-rights-and-democracy-programme",
+        "/guidance/laying-hens-looking-after-their-welfare"
+      ]
+    },
+    {
+      "name": "help_page",
+      "count": 8,
+      "schema_names": [
+        "placeholder"
+      ],
+      "publishing_apps": [
+        "publisher"
+      ],
+      "rendering_apps": [
+        "frontend"
+      ],
+      "examples": [
+        "/help/about-govuk",
+        "/help/accessibility",
+        "/help/beta",
+        "/help/browsers",
+        "/help/cookies",
+        "/help/privacy-policy",
+        "/help/terms-conditions",
+        "/help/update-email-notifications"
+      ]
+    },
+    {
+      "name": "hmrc_manual",
+      "count": 217,
+      "schema_names": [
+        "hmrc_manual"
+      ],
+      "publishing_apps": [
+        "hmrc-manuals-api"
+      ],
+      "rendering_apps": [
+        "manuals-frontend"
+      ],
+      "examples": [
+        "/hmrc-internal-manuals/admin-law-manual",
+        "/hmrc-internal-manuals/aggregates-levy",
+        "/hmrc-internal-manuals/air-passenger-duty",
+        "/hmrc-internal-manuals/air-passenger-duty-risk",
+        "/hmrc-internal-manuals/alcohol-wholesaler-registration-scheme",
+        "/hmrc-internal-manuals/animation-production-company-manual",
+        "/hmrc-internal-manuals/anti-dumping-and-countervailing-duties",
+        "/hmrc-internal-manuals/appeals-reviews-and-tribunals-guidance",
+        "/hmrc-internal-manuals/ata-cpd-carnets",
+        "/hmrc-internal-manuals/bank-levy-manual"
+      ]
+    },
+    {
+      "name": "hmrc_manual_section",
+      "count": 73302,
+      "schema_names": [
+        "hmrc_manual_section"
+      ],
+      "publishing_apps": [
+        "hmrc-manuals-api"
+      ],
+      "rendering_apps": [
+        "manuals-frontend"
+      ],
+      "examples": [
+        "/hmrc-internal-manuals/admin-law-manual/adml1000",
+        "/hmrc-internal-manuals/admin-law-manual/adml1100",
+        "/hmrc-internal-manuals/admin-law-manual/adml1200",
+        "/hmrc-internal-manuals/admin-law-manual/adml1300",
+        "/hmrc-internal-manuals/admin-law-manual/adml1400",
+        "/hmrc-internal-manuals/admin-law-manual/adml1500",
+        "/hmrc-internal-manuals/admin-law-manual/adml1600",
+        "/hmrc-internal-manuals/admin-law-manual/adml1605",
+        "/hmrc-internal-manuals/admin-law-manual/adml1610",
+        "/hmrc-internal-manuals/admin-law-manual/adml1620"
+      ]
+    },
+    {
+      "name": "international_development_fund",
+      "count": 53,
+      "schema_names": [
+        "specialist_document"
+      ],
+      "publishing_apps": [
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "specialist-frontend"
+      ],
+      "examples": [
+        "/international-development-funding/africa-agriculture-development-company",
+        "/international-development-funding/africa-enterprise-challenge-fund",
+        "/international-development-funding/amplify-collaborative-challenge-fund",
+        "/international-development-funding/behaviour-change-in-low-income-households-unilever-partnership",
+        "/international-development-funding/business-call-to-action",
+        "/international-development-funding/business-innovation-facility",
+        "/international-development-funding/business-sector-advocacy-challenge-fund-ghana",
+        "/international-development-funding/capacity-development-fund-for-education-in-rwanda",
+        "/international-development-funding/common-ground-initiative-cgi",
+        "/international-development-funding/common-humanitarian-fund-for-somalia"
+      ]
+    },
+    {
+      "name": "placeholder_licence_finder",
+      "count": 1,
+      "schema_names": [
+        "placeholder_licence_finder"
+      ],
+      "publishing_apps": [
+        "licencefinder"
+      ],
+      "rendering_apps": [
+        "licencefinder"
+      ],
+      "examples": [
+        "/licence-finder"
+      ]
+    },
+    {
+      "name": "financial_releases_geoblocker",
+      "count": 5,
+      "schema_names": [
+        "financial_releases_geoblocker"
+      ],
+      "publishing_apps": [
+        "share-sale-publisher"
+      ],
+      "rendering_apps": [
+        "email-campaign-frontend"
+      ],
+      "examples": [
+        "/lloydsfactsheet/location",
+        "/lloydsshares/lloyds-share-offer-press-releases/location",
+        "/lloydsshares/lloyds-share-offer/location",
+        "/lloydsshares/location",
+        "/location/not-permitted"
+      ]
+    },
+    {
+      "name": "financial_releases_campaign",
+      "count": 1,
+      "schema_names": [
+        "financial_releases_campaign"
+      ],
+      "publishing_apps": [
+        "share-sale-publisher"
+      ],
+      "rendering_apps": [
+        "email-campaign-frontend"
+      ],
+      "examples": [
+        "/lloydsshares"
+      ]
+    },
+    {
+      "name": "financial_release",
+      "count": 1,
+      "schema_names": [
+        "financial_release"
+      ],
+      "publishing_apps": [
+        "share-sale-publisher"
+      ],
+      "rendering_apps": [
+        "email-campaign-frontend"
+      ],
+      "examples": [
+        "/lloydsshares/lloyds-share-offer"
+      ]
+    },
+    {
+      "name": "financial_releases_index",
+      "count": 1,
+      "schema_names": [
+        "financial_releases_index"
+      ],
+      "publishing_apps": [
+        "share-sale-publisher"
+      ],
+      "rendering_apps": [
+        "email-campaign-frontend"
+      ],
+      "examples": [
+        "/lloydsshares/lloyds-share-offer-press-releases"
+      ]
+    },
+    {
+      "name": "financial_releases_success",
+      "count": 1,
+      "schema_names": [
+        "financial_releases_success"
+      ],
+      "publishing_apps": [
+        "share-sale-publisher"
+      ],
+      "rendering_apps": [
+        "email-campaign-frontend"
+      ],
+      "examples": [
+        "/lloydsshares/register-interest-success"
+      ]
+    },
+    {
+      "name": "maib_report",
+      "count": 871,
+      "schema_names": [
+        "specialist_document"
+      ],
+      "publishing_apps": [
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "specialist-frontend"
+      ],
+      "examples": [
+        "/maib-reports/-failure-of-lifeboat-davit-on-dry-cargo-vessel-st-rognvald-resulting-in-several-injuries-to-crew-members",
+        "/maib-reports/accident-involving-unguarded-riddle-on-multipurpose-fishing-vessel-sian-elizabeth-off-kings-lynn-england-with-1-person-injured",
+        "/maib-reports/accident-to-person-while-bulk-carrier-fitnes-was-self-discharging-cargo-at-northfleet-river-thames-england-with-loss-of-1-life",
+        "/maib-reports/accident-to-shore-worker-while-disembarking-passenger-vessel-oldenburg-with-1-fatality",
+        "/maib-reports/accident-to-skipper-of-scallop-dredger-ronan-orla-with-loss-of-1-life",
+        "/maib-reports/accident-while-boarding-dive-support-boat-sovereign-ii-off-lee-shore-farne-islands-england-with-1-person-injured",
+        "/maib-reports/accident-while-emptying-catch-from-dredges-on-scallop-dredger-wanderer-ii-with-1-person-injured",
+        "/maib-reports/accident-while-hauling-gear-during-heavy-weather-on-stern-trawler-venture-ii-off-the-north-west-coast-of-scotland-with-loss-of-1-life",
+        "/maib-reports/accident-while-lowering-bow-visor-of-ro-ro-passenger-ferry-fivla-in-bluemull-sound-shetland-scotland-with-loss-of-1-life",
+        "/maib-reports/accident-while-unloading-from-general-cargo-vessel-excalibur-with-loss-of-1-life"
+      ]
+    },
+    {
+      "name": "raib_report",
+      "count": 346,
+      "schema_names": [
+        "specialist_document"
+      ],
+      "publishing_apps": [
+        "specialist-publisher"
+      ],
+      "rendering_apps": [
+        "specialist-frontend"
+      ],
+      "examples": [
+        "/raib-reports/accident-at-balnamore-level-crossing-ballymoney-northern-ireland-31-may-2013",
+        "/raib-reports/accident-at-charing-cross-station",
+        "/raib-reports/accident-at-dalston-junction",
+        "/raib-reports/accident-at-falls-of-cruachan-argyll",
+        "/raib-reports/accident-at-grosvenor-bridge-near-london-victoria",
+        "/raib-reports/accident-at-leatherhead",
+        "/raib-reports/accident-at-margam-yard-near-port-talbot-12-june-2012",
+        "/raib-reports/accident-at-moor-lane-footpath-level-crossing-in-staines-surrey",
+        "/raib-reports/accident-at-west-lodge-level-crossing-near-haltwhistle-northumberland",
+        "/raib-reports/accident-involving-a-pantograph-and-the-overhead-line-near-littleport-cambridge"
+      ]
+    },
+    {
+      "name": "service_manual_topic",
+      "count": 8,
+      "schema_names": [
+        "service_manual_topic"
+      ],
+      "publishing_apps": [
+        "service-manual-publisher"
+      ],
+      "rendering_apps": [
+        "service-manual-frontend"
+      ],
+      "examples": [
+        "/service-manual/agile-delivery",
+        "/service-manual/communities",
+        "/service-manual/helping-people-to-use-your-service",
+        "/service-manual/measuring-success",
+        "/service-manual/service-assessments",
+        "/service-manual/technology",
+        "/service-manual/the-team",
+        "/service-manual/user-research"
+      ]
+    },
+    {
+      "name": "service_manual_guide",
+      "count": 103,
+      "schema_names": [
+        "service_manual_guide"
+      ],
+      "publishing_apps": [
+        "service-manual-publisher"
+      ],
+      "rendering_apps": [
+        "service-manual-frontend"
+      ],
+      "examples": [
+        "/service-manual/agile-delivery/agile-government-services-introduction",
+        "/service-manual/agile-delivery/agile-methodologies",
+        "/service-manual/agile-delivery/agile-tools-techniques",
+        "/service-manual/agile-delivery/apply-for-approval-to-spend-money-on-a-service",
+        "/service-manual/agile-delivery/core-principles-agile",
+        "/service-manual/agile-delivery/create-agile-working-environment",
+        "/service-manual/agile-delivery/governance-principles-for-agile-service-delivery",
+        "/service-manual/agile-delivery/how-the-alpha-phase-works",
+        "/service-manual/agile-delivery/how-the-beta-phase-works",
+        "/service-manual/agile-delivery/how-the-discovery-phase-works"
+      ]
+    },
+    {
+      "name": "service_manual_service_standard",
+      "count": 1,
+      "schema_names": [
+        "service_manual_service_standard"
+      ],
+      "publishing_apps": [
+        "service-manual-publisher"
+      ],
+      "rendering_apps": [
+        "service-manual-frontend"
+      ],
+      "examples": [
+        "/service-manual/service-standard"
+      ]
+    },
+    {
+      "name": "topic",
+      "count": 397,
+      "schema_names": [
+        "topic"
+      ],
+      "publishing_apps": [
+        "collections-publisher"
+      ],
+      "rendering_apps": [
+        "collections"
+      ],
+      "examples": [
+        "/topic",
+        "/topic/animal-welfare",
+        "/topic/animal-welfare/pets",
+        "/topic/benefits-credits",
+        "/topic/benefits-credits/child-benefit",
+        "/topic/benefits-credits/universal-credit",
+        "/topic/business-enterprise",
+        "/topic/business-enterprise/business-auditing-accounting-reporting",
+        "/topic/business-enterprise/european-regional-development-funding",
+        "/topic/business-enterprise/export-finance"
+      ]
+    }
+  ],
+  "generated_at": "2016-11-14 18:05:20 +0000"
+}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,41 +1,7 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta charset="utf-8">
-    <title>
-      {% if page.title == null %}
-        {{ site.name }}
-      {% else %}
-        {{ page.title }} - {{ site.name }}
-      {% endif %}
-    </title>
-    <meta name="viewport" content="width=device-width">
-    <link rel="stylesheet" href="{{ site.baseurl }}/css/fonts.css">
-    <link rel="stylesheet" href="{{ site.baseurl }}/css/govuk-template.css">
-    <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
-  </head>
-  <body>
-    <div class="container">
-      <main id="page-container" role="main">
-        <div class="column-full-width">
-          <h1 class="page-title">GOV.UK: {{ page.title }}</h1>
+---
+layout: main
+---
 
-          <ul class='navigation'>
-            {% for p in site.pages %}
-              {% if p.title != nil %}
-              <li>
-                <a {% if p.url == page.url %}class="active"{% endif %} href="{{ p.path }}">
-                  {{ p.title }}
-                </a>
-              </li>
-              {% endif %}
-            {% endfor %}
-          </ul>
+<h1 class="page-title">{{ page.title }}</h1>
 
-          {{ content }}
-        </div>
-      </main>
-    </div>
-    </body>
-</html>
+{{ content }}

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8">
+    <title>
+      {% if page.title == null %}
+        {{ site.name }}
+      {% else %}
+        {{ page.title }} - {{ site.name }}
+      {% endif %}
+    </title>
+    <meta name="viewport" content="width=device-width">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/fonts.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/govuk-template.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
+  </head>
+  <body>
+    <div class="container">
+      <main id="page-container" role="main">
+        <div class="column-full-width">
+          <div class='navigation'>
+            <a href='{{ site.baseurl }}/index.html'>Applications &amp; development</a> |
+            <a href='{{ site.baseurl }}/operations.html'>Operations</a> |
+            <a href='{{ site.baseurl }}/document-types.html'>Document types</a>
+          </div>
+
+          {{ content }}
+        </div>
+      </main>
+    </div>
+    </body>
+</html>

--- a/css/main.scss
+++ b/css/main.scss
@@ -56,3 +56,7 @@ h2 {
     color: $text-colour;
   }
 }
+
+.document-type {
+  margin-bottom: 30px;
+}

--- a/document-types.html
+++ b/document-types.html
@@ -1,0 +1,28 @@
+---
+layout: default
+title: GOV.UK Document Types
+---
+
+{% assign document_types = site.data.content_stats.document_types | sort: 'name' %}
+{% for document_type in document_types %}
+  <div class='document-type'>
+    <h3>{{ document_type.name }}</h3>
+    {{ document_type.count }} items<br/>
+    Rendered by: {{ document_type.rendering_apps || join: ", " }}<br/>
+    Published by: {{ document_type.publishing_apps || join: ", " }}<br/>
+
+    Schema(s):
+    <ul>
+    {% for schema_name in document_type.schema_names %}
+      <li><a href='https://github.com/alphagov/govuk-content-schemas/tree/master/dist/formats/contact{{ schema_name }}'>{{ schema_name }}</a></li>
+    {% endfor %}
+    </ul>
+
+    Examples:
+    <ul>
+    {% for example in document_type.examples %}
+      <li><a href='https://www.gov.uk{{ example }}'>{{ example }}</a></li>
+    {% endfor %}
+    </ul>
+  </div>
+{% endfor %}


### PR DESCRIPTION
Very experimental.

Shows a list of document types on GOV.UK, along with examples and information about applications.

Data from: https://github.com/alphagov/content-store/tree/add-stats-task
