### PR TITLE
Configure for Heroku hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .sass-cache
+build

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,6 @@ gem 'redcarpet', '~> 3.3.2'
 # GitHub API
 gem 'octokit'
 gem 'faraday-http-cache'
+
+# For hosting on Heroku
+gem 'rack-contrib'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby File.read('.ruby-version').chomp
+
 gem 'rake'
 gem 'rspec', '~> 3.5'
 gem 'webmock', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       activesupport (>= 3.1)
     parallel (1.10.0)
     rack (2.0.1)
+    rack-contrib (1.2.0)
+      rack (>= 0.9.1)
     rack-livereload (0.3.16)
       rack
     rake (11.1.2)
@@ -165,6 +167,7 @@ DEPENDENCIES
   middleman-livereload
   middleman-sprockets (~> 4.0.0)
   octokit
+  rack-contrib
   rake
   redcarpet (~> 3.3.2)
   rspec (~> 3.5)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > ⚠️ This project is being rebuilt and is undergoing rapid change. File an issue before opening a PR.
 
 
-Live at: [alphagov.github.com/govuk-developers](https://alphagov.github.com/govuk-developers)
+Live at: https://govuk-tech-docs.herokuapp.com (normal GDS username/password)
 
 ## Technical documentation
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+namespace :assets do
+  task :precompile do
+    sh 'middleman build'
+  end
+end

--- a/config.rb
+++ b/config.rb
@@ -14,9 +14,6 @@ activate :sprockets
 configure :build do
 end
 
-# Set the directory to /docs so GitHub can serve it
-set :build_dir, 'docs'
-
 require_relative './lib/dashboard/dashboard'
 
 helpers do

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,13 @@
+# For hosting on Heroku
+require 'rack'
+require 'rack/contrib/try_static'
+
+# Serve files from the build directory
+use Rack::TryStatic,
+  root: 'build',
+  urls: %w[/],
+  try: ['.html', 'index.html', '/index.html']
+
+run lambda { |env|
+  [ 404, { 'Content-Type'  => 'text/html'}, [ "404 Not Found" ]]
+}

--- a/config.ru
+++ b/config.ru
@@ -2,6 +2,11 @@
 require 'rack'
 require 'rack/contrib/try_static'
 
+# "restrict" access for now
+use Rack::Auth::Basic, "Restricted Area" do |username, password|
+  [username, password] == [ENV['AUTH_USERNAME'], ENV['AUTH_PASSWORD']]
+end
+
 # Serve files from the build directory
 use Rack::TryStatic,
   root: 'build',

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,1 @@
+<a href='http://govuk-tech-docs.herokuapp.com/'>Go to govuk-tech-docs.herokuapp.com</a>


### PR DESCRIPTION
We can't use the crown & font on non-gov.uk sites. Hosting on Heroku allows us to use HTTP auth.

Also brings us awesomeness like auto-deploying review apps for each PR.