### PR TITLE
Add schema documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,11 @@ gem 'middleman', '>= 4.0.0'
 gem 'middleman-livereload'
 gem 'middleman-compass', '>= 4.0.0'
 gem 'middleman-sprockets', '~> 4.0.0'
+gem 'middleman-syntax', '~> 3.0.0'
 
 gem 'redcarpet', '~> 3.3.2'
+
+gem 'govuk_schemas', '~> 2.0.0'
 
 # GitHub API
 gem 'octokit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
     fastimage (2.0.1)
       addressable (~> 2)
     ffi (1.9.14)
+    govuk_schemas (2.0.0)
+      json-schema (~> 2.5.0)
     haml (4.0.7)
       tilt
     hamster (3.0.0)
@@ -53,6 +55,8 @@ GEM
     hashie (3.4.6)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
+    json-schema (2.5.2)
+      addressable (~> 2.3.8)
     kramdown (1.13.1)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -101,6 +105,9 @@ GEM
     middleman-sprockets (4.0.0)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
+    middleman-syntax (3.0.0)
+      middleman-core (>= 3.2)
+      rouge (~> 2.0)
     minitest (5.9.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
@@ -123,6 +130,7 @@ GEM
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     redcarpet (3.3.3)
+    rouge (2.0.7)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -162,10 +170,12 @@ PLATFORMS
 
 DEPENDENCIES
   faraday-http-cache
+  govuk_schemas (~> 2.0.0)
   middleman (>= 4.0.0)
   middleman-compass (>= 4.0.0)
   middleman-livereload
   middleman-sprockets (~> 4.0.0)
+  middleman-syntax (~> 3.0.0)
   octokit
   rack-contrib
   rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 namespace :assets do
   task :precompile do
-    sh 'middleman build'
+    sh 'git clone https://github.com/alphagov/govuk-content-schemas.git /tmp/govuk-content-schemas --depth=1 && GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas middleman build'
   end
 end

--- a/config.rb
+++ b/config.rb
@@ -10,6 +10,7 @@ configure :development do
 end
 
 activate :sprockets
+activate :syntax
 
 configure :build do
 end
@@ -17,6 +18,7 @@ end
 require_relative './lib/dashboard/dashboard'
 require_relative './lib/external_doc'
 require_relative './lib/publishing_api_docs'
+require_relative './lib/content_schemas/content_schema'
 
 helpers do
   def dashboard
@@ -29,11 +31,21 @@ helpers do
 end
 
 ignore 'publishing_api_template.html.md.erb'
+ignore 'schema_template.html.md.erb'
 
 PublishingApiDocs.pages.each do |page|
   proxy "/apis/publishing-api/#{page.filename}.html", "publishing_api_template.html", locals: {
     page_title: page.title,
     page: page,
+  }
+end
+
+ContentSchema.schema_names.each do |schema_name|
+  schema = ContentSchema.new(schema_name)
+
+  proxy "/content-schemas/#{schema_name}.html", "schema_template.html", locals: {
+    schema: schema,
+    page_title: "Schema: #{schema.schema_name}",
   }
 end
 

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -9,3 +9,4 @@ header_links:
   Dashboard: /
   Publishing API: /apis/publishing-api.html
   Search API: /apis/search-api.html
+  Content Schemas: /content-schemas.html

--- a/helpers/properties_table_helpers.rb
+++ b/helpers/properties_table_helpers.rb
@@ -1,0 +1,35 @@
+module PropertiesTableHelpers
+  def table_of_properties(properties)
+    return unless properties
+
+    rows = properties.map do |name, attrs|
+      "<tr><td><strong>#{name}</strong><br/>#{possible_types(attrs)}</td> <td>#{display_attribute_value(attrs)}</td></tr>"
+    end
+
+    "<table class='schema-table'>#{rows.join("\n")}</table>"
+  end
+
+private
+
+  def display_attribute_value(attrs)
+    return unless attrs
+
+    if attrs['properties']
+      table_of_properties(attrs['properties'])
+    else
+      [attrs['description'], enums(attrs)].join("<br/>")
+    end
+  end
+
+  def enums(attrs)
+    return unless attrs['enum']
+    "Allowed values: " + attrs['enum'].map { |value| "<code>#{value}</code>" }.join(", ")
+  end
+
+  def possible_types(attrs)
+    return unless attrs
+    possible_types = attrs['type'] ? [attrs] : attrs['anyOf']
+    return unless possible_types
+    possible_types.map { |a| "<code>#{a['type']}</code>" }.join(" or ")
+  end
+end

--- a/lib/content_schemas/content_schema.rb
+++ b/lib/content_schemas/content_schema.rb
@@ -1,0 +1,139 @@
+require 'json'
+require 'active_support/core_ext/string'
+require 'govuk_schemas'
+
+class ContentSchema
+  # TODO: Move this method into the govuk_schemas gem.
+  def self.schema_names
+    Dir.glob("#{GovukSchemas::CONTENT_SCHEMA_DIR}/dist/formats/*").map do |directory|
+      File.basename(directory)
+    end
+  end
+
+  attr_reader :schema_name
+
+  def initialize(schema_name)
+    @schema_name = schema_name
+  end
+
+  def frontend_schema
+    FrontendSchema.new(schema_name)
+  rescue Errno::ENOENT
+    nil
+  end
+
+  def publisher_content_schema
+    PublisherContentSchema.new(schema_name)
+  rescue Errno::ENOENT
+    nil
+  end
+
+  def publisher_links_schema
+    PublisherLinksSchema.new(schema_name)
+  rescue Errno::ENOENT
+    nil
+  end
+
+  class FrontendSchema
+    attr_reader :schema_name
+
+    def initialize(schema_name)
+      @schema_name = schema_name
+      raw_schema
+    end
+
+    def link_to_github
+      "https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/#{schema_name}/frontend/schema.json"
+    end
+
+    def random_example
+      GovukSchemas::RandomExample.new(schema: raw_schema).payload
+    end
+
+    def properties
+      Utils.inline_definitions(raw_schema['properties'], raw_schema['definitions'])
+    end
+
+  private
+
+    def raw_schema
+      @raw_schema ||= GovukSchemas::Schema.find(frontend_schema: schema_name)
+    end
+  end
+
+  class PublisherContentSchema
+    attr_reader :schema_name
+
+    def initialize(schema_name)
+      @schema_name = schema_name
+      raw_schema
+    end
+
+    def link_to_github
+      "https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/#{schema_name}/publisher/schema.json"
+    end
+
+    def random_example
+      GovukSchemas::RandomExample.new(schema: raw_schema).payload
+    end
+
+    def properties
+      Utils.inline_definitions(raw_schema['properties'], raw_schema['definitions'])
+    end
+
+  private
+
+    def raw_schema
+      @raw_schema ||= GovukSchemas::Schema.find(publisher_schema: schema_name)
+    end
+  end
+
+  class PublisherLinksSchema
+    attr_reader :schema_name
+
+    def initialize(schema_name)
+      @schema_name = schema_name
+      raw_schema
+    end
+
+    def link_to_github
+      "https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/#{schema_name}/publisher/links.json"
+    end
+
+    def random_example
+      GovukSchemas::RandomExample.new(schema: raw_schema).payload
+    end
+
+    def properties
+      Utils.inline_definitions(raw_schema['properties'], raw_schema['definitions'])
+    end
+
+  private
+
+    def raw_schema
+      @raw_schema ||= GovukSchemas::Schema.find(links_schema: schema_name)
+    end
+  end
+
+  module Utils
+    # Inline any keys that use definitions
+    def self.inline_definitions(original_properties, definitions)
+      original_properties.to_h.each do |k, v|
+        next unless v['$ref']
+        original_properties[k] = definitions[v['$ref'].gsub('#/definitions/', '')]
+      end
+
+      # Inline any keys that use definitions
+      if original_properties.to_h.dig('details', 'properties')
+        original_properties['details']['properties'].each do |k, v|
+          next unless v['$ref']
+          definition_name = v['$ref'].gsub('#/definitions/', '')
+          original_properties['details']['properties'][k] = definitions.fetch(definition_name)
+        end
+      end
+
+      # Sort by keyname
+      Hash[original_properties.to_h.sort_by(&:first)]
+    end
+  end
+end

--- a/source/content-schemas.html.md.erb
+++ b/source/content-schemas.html.md.erb
@@ -1,0 +1,9 @@
+---
+layout: schema_layout
+title: Content schemas
+navigation_weight: 5
+---
+
+The content schemas are defined in the [govuk-content-schemas repo][repo].
+
+[repo]: https://github.com/alphagov/govuk-content-schemas

--- a/source/layouts/schema_layout.erb
+++ b/source/layouts/schema_layout.erb
@@ -1,0 +1,42 @@
+<% wrap_layout :header_footer_only do %>
+  <div id="toc-heading" class="toc-show fixedsticky">
+    <a href="#toc" class="toc-show__label js-toc-show">
+      Table of contents <span class="toc-show__icon"></span>
+    </a>
+  </div>
+
+  <div class="app-pane__body">
+    <div class="app-pane__toc">
+      <div class="toc" data-module="table-of-contents">
+        <a href="#" class="toc__close js-toc-close">Close</a>
+        <nav  id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
+          <ul>
+            <% ContentSchema.schema_names.each do |schema_name| %>
+              <li><%= link_to schema_name, "/content-schemas/#{schema_name}.html" %></li>
+              <% if current_page.path.include?("content-schemas/#{schema_name}.html") %>
+                <ul>
+                  <li><%= link_to 'Frontend schema', '#frontend-schema' %>
+                  <li><%= link_to 'Publisher content schema', '#publisher-content-schema' %>
+                  <li><%= link_to 'Publisher links schema', '#publisher-links-schema' %>
+                </ul>
+              <% end %>
+            <% end %>
+          </ul>
+        </nav>
+      </div>
+    </div>
+
+    <div class="app-pane__content">
+      <main id="content" class="technical-documentation" data-module="anchored-headings">
+        <%= partial 'partials/header' %>
+        <%= yield %>
+      </main>
+    </div>
+  </div>
+
+  <style media="screen">
+    .technical-documentation pre {
+      max-height: 400px;
+    }
+  </style>
+<% end %>

--- a/source/schema_template.html.md.erb
+++ b/source/schema_template.html.md.erb
@@ -1,0 +1,75 @@
+---
+layout: schema_layout
+parent: content-schemas.html
+---
+
+## Frontend schema
+
+<% if schema.frontend_schema %>
+
+This schema describes the content item that is returned from the
+[content store](https://github.com/alphagov/content-store).
+
+<%= table_of_properties(schema.frontend_schema.properties) %>
+
+[View this schema on GitHub](<%= schema.frontend_schema.link_to_github %>)
+
+### Random example
+
+```json
+<%= JSON.pretty_generate(schema.frontend_schema.random_example) %>
+```
+
+<% else %>
+This schema doesn't have a frontend schema. This means that it should not be
+used by rendering applications.
+<% end %>
+
+---
+
+<% if schema.publisher_content_schema %>
+
+## Publisher content schema
+
+This is what publisher apps should send to the publishing-api in This is what
+a publishing application sends to the publishing-api in a
+[`put_content`](http://www.rubydoc.info/github/alphagov/gds-api-adapters/GdsApi/PublishingApiV2#put_content-instance_method) call.
+
+### Attributes
+
+<%= table_of_properties(schema.publisher_content_schema.properties) %>
+
+[View this schema on GitHub](<%= schema.publisher_content_schema.link_to_github %>)
+
+### Random example
+
+```json
+<%= JSON.pretty_generate(schema.publisher_content_schema.random_example) %>
+```
+
+<% end %>
+
+---
+
+## Publisher links schema
+
+<% if schema.publisher_links_schema %>
+
+The links for this item. This is what a publishing application sends in a
+[`patch_links`](http://www.rubydoc.info/github/alphagov/gds-api-adapters/GdsApi/PublishingApiV2#patch_links-instance_method) call.
+
+### Attributes
+
+<%= table_of_properties(schema.publisher_links_schema.properties) %>
+
+[View this schema on GitHub](<%= schema.publisher_links_schema.link_to_github %>)
+
+### Random example
+
+```json
+<%= JSON.pretty_generate(schema.publisher_links_schema.random_example) %>
+```
+
+<% else %>
+This schema does not allow for setting of links.
+<% end %>


### PR DESCRIPTION
This PR adds documentation for the [govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas).

https://trello.com/c/B7iFo5SN/2-create-documentation-for-content-schemas
