### PR TITLE
Pull in rummager's search documentation

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -15,6 +15,7 @@ configure :build do
 end
 
 require_relative './lib/dashboard/dashboard'
+require_relative './lib/external_doc'
 
 helpers do
   def dashboard

--- a/lib/external_doc.rb
+++ b/lib/external_doc.rb
@@ -1,0 +1,10 @@
+class ExternalDoc
+  def self.fetch(url_to_markdown)
+    markdown = Faraday.get(url_to_markdown).body
+
+    # remove the own title of the page
+    markdown = markdown.lines[2..-1].join.strip
+
+    markdown
+  end
+end

--- a/source/apis/search-api.html.md.erb
+++ b/source/apis/search-api.html.md.erb
@@ -1,0 +1,9 @@
+---
+layout: api_layout
+title: Search API
+navigation_weight: 20
+source_url: https://github.com/alphagov/rummager/blob/master/docs/search-api.md
+edit_url: https://github.com/alphagov/rummager/edit/master/docs/search-api.md
+---
+
+<%= ExternalDoc.fetch('https://raw.githubusercontent.com/alphagov/rummager/master/docs/search-api.md') %>

--- a/source/layouts/api_layout.html.erb
+++ b/source/layouts/api_layout.html.erb
@@ -1,0 +1,17 @@
+<% wrap_layout :default do %>
+  <div class="app-pane__toc">
+    <nav class="toc">
+      <ul>
+        <li><%= link_to 'Search API', '/apis/search-api.html' %></li>
+      </ul>
+    </nav>
+  </div>
+
+  <div class="app-pane__content">
+    <div id="content" class="technical-documentation">
+      <%= partial 'partials/header' %>
+      <%= yield %>
+      <%= partial 'partials/source' %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
This PR adds pulls in the rummager documentation page for the search API.

https://github.com/alphagov/rummager/blob/master/docs/search-api.md

I think this is probably the most useful page for rummager. I've considered also pulling in pages like [indexing](https://github.com/alphagov/rummager/blob/master/docs/documents.md) docs, but they seem less complete at the moment. Perhaps we can start with this page and see how it's used?

Thoughts @MatMoore?