### PR TITLE
Add docs for publishing-api

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -16,9 +16,23 @@ end
 
 require_relative './lib/dashboard/dashboard'
 require_relative './lib/external_doc'
+require_relative './lib/publishing_api_docs'
 
 helpers do
   def dashboard
     Dashboard.new
   end
+
+  def publishing_api_pages
+    PublishingApiDocs.pages
+  end
+end
+
+ignore 'publishing_api_template.html.md.erb'
+
+PublishingApiDocs.pages.each do |page|
+  proxy "/apis/publishing-api/#{page.filename}.html", "publishing_api_template.html", locals: {
+    page_title: page.title,
+    page: page,
+  }
 end

--- a/helpers/navigation_helpers.rb
+++ b/helpers/navigation_helpers.rb
@@ -1,0 +1,5 @@
+module NavigationHelpers
+  def active_page?(page_path)
+    current_page.path.start_with?(page_path) || current_page.data.parent == page_path
+  end
+end

--- a/lib/external_doc.rb
+++ b/lib/external_doc.rb
@@ -5,6 +5,9 @@ class ExternalDoc
     # remove the own title of the page
     markdown = markdown.lines[2..-1].join.strip
 
+    # Make sure we link to the pages hosted here
+    markdown = markdown.gsub('.md', '.html')
+
     markdown
   end
 end

--- a/lib/publishing_api_docs.rb
+++ b/lib/publishing_api_docs.rb
@@ -1,0 +1,35 @@
+class PublishingApiDocs
+  PAGES = {
+    "api" => "API docs",
+    "dependency-resolution" => "Dependency resolution",
+    "link-expansion" => "Link expansion",
+    "model" => "Model",
+    "publishing-application-examples" => "Examples",
+    "rabbitmq" => "Message queue",
+  }
+
+  def self.pages
+    PAGES.map { |k, v| Page.new(k, v) }
+  end
+
+  class Page
+    attr_reader :filename, :title
+
+    def initialize(filename, title)
+      @filename = filename
+      @title = title
+    end
+
+    def source_url
+      "https://github.com/alphagov/publishing-api/blob/master/doc/#{filename}.md"
+    end
+
+    def edit_url
+      "https://github.com/alphagov/publishing-api/edit/master/doc/#{filename}.md"
+    end
+
+    def raw_source
+      "https://raw.githubusercontent.com/alphagov/publishing-api/master/doc/#{filename}.md"
+    end
+  end
+end

--- a/source/apis/publishing-api.html.md.erb
+++ b/source/apis/publishing-api.html.md.erb
@@ -1,0 +1,14 @@
+---
+layout: api_layout
+title: Publishing API
+navigation_weight: 15
+---
+
+The [Publishing API][repo] is the central
+application for publishing to GOV.UK.
+
+The docs here are imported from the [docs directory][docs-directory]
+in the [publishing-api repo][repo].
+
+[docs-directory]: https://github.com/alphagov/publishing-api/tree/master/doc
+[repo]: https://github.com/alphagov/publishing-api

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -44,6 +44,6 @@ edit_url: https://github.com/alphagov/govuk-developers/edit/master/data/dashboar
       <% end %>
     <% end %>
 
-    <%= partial 'partials/source' %>
+    <%= partial 'partials/source', locals: { page: current_page.data } %>
   </div>
 </div>

--- a/source/layouts/api_layout.html.erb
+++ b/source/layouts/api_layout.html.erb
@@ -3,6 +3,14 @@
     <nav class="toc">
       <ul>
         <li><%= link_to 'Search API', '/apis/search-api.html' %></li>
+        <li>
+          <%= link_to 'Publishing API', '/apis/publishing-api.html' %>
+          <ul>
+            <% publishing_api_pages.each do |page| %>
+              <li><%= link_to page.title, "/apis/publishing-api/#{page.filename}.html" %></li>
+            <% end %>
+          </ul>
+        </li>
       </ul>
     </nav>
   </div>
@@ -10,8 +18,15 @@
   <div class="app-pane__content">
     <div id="content" class="technical-documentation">
       <%= partial 'partials/header' %>
+      <% if locals.key?(:page) %>
+        <%= partial 'partials/source', page: page %>
+      <% end %>
+
       <%= yield %>
-      <%= partial 'partials/source' %>
+
+      <% if locals.key?(:page) %>
+        <%= partial 'partials/source', page: page %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/source/layouts/default.erb
+++ b/source/layouts/default.erb
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width">
 
     <title>
-      <%= current_page.data.title %> - GOV.UK Developers Documentation
+      <%= locals.key?(:page_title) ? page_title : current_page.data.title %> - GOV.UK Developer Documentation
     </title>
 
     <link rel="stylesheet" href="/assets/css/stolen-from-docs.css">
@@ -41,7 +41,7 @@
             <nav id="navigation" class="header__navigation">
               <ul>
                 <% sitemap.resources.select { |p| p.data.navigation_weight }.sort_by { |p| p.data.navigation_weight }.each do |page| %>
-                  <li class="<%= current_page.path.start_with?(page.path) ? "active" : "" %>">
+                  <li class="<%= active_page?(page.path) ? "active" : "" %>">
                     <a href="<%= page.url %>">
                       <%= page.data.title %>
                     </a>

--- a/source/partials/_header.html.erb
+++ b/source/partials/_header.html.erb
@@ -1,1 +1,1 @@
-<h1 class="page-title"><%= current_page.data.title %></h1>
+<h1 class="page-title"><%= locals.key?(:page_title) ? page_title : current_page.data.title %></h1>

--- a/source/partials/_source.html.erb
+++ b/source/partials/_source.html.erb
@@ -1,5 +1,5 @@
 <div class="edit-links">
   Something wrong? Something to add?
-  <%= link_to "View source on GitHub", current_page.data.source_url %> or
-  <%= link_to "edit directly on GitHub", current_page.data.edit_url %>.
+  <%= link_to "View source on GitHub", page.source_url %> or
+  <%= link_to "edit directly on GitHub", page.edit_url %>.
 </div>

--- a/source/publishing_api_template.html.md.erb
+++ b/source/publishing_api_template.html.md.erb
@@ -1,0 +1,6 @@
+---
+layout: api_layout
+parent: apis/publishing-api.html
+---
+
+<%= ExternalDoc.fetch(page.raw_source) %>


### PR DESCRIPTION
This adds the documentation for the publishing-api docs.

The list of pages to import is hard coded. I've considered using the GitHub API to fetch everything in the `/doc` directory. The downside to that is that if pages are renamed, we'll inadvertently break the pages here. Having a local list here allows us to set up redirects.

https://trello.com/c/aW1dfqD3